### PR TITLE
Return the value of the user's rating in the apptypes endpoint

### DIFF
--- a/marketplace/applications/serializers.py
+++ b/marketplace/applications/serializers.py
@@ -1,3 +1,4 @@
+from marketplace.interactions.models import Rating
 from rest_framework import serializers
 from marketplace.core.types.base import AppType
 
@@ -33,8 +34,16 @@ class AppTypeSerializer(serializers.Serializer):
         ]
 
     def get_rating(self, obj) -> dict:
-        # TODO: Return too the "mine" field
-        return dict(average=obj.get_ratings_average())
+        rating = dict(average=obj.get_ratings_average(), mine=None)
+
+        user = self.context["request"].user
+        try:
+            rating_instance = user.created_ratings.get(app_code=obj.code)
+            rating["mine"] = rating_instance.rate
+        except Rating.DoesNotExist:
+            pass
+
+        return rating
 
     def get_comments_count(self, obj) -> int:
         return obj.comments.count()

--- a/marketplace/applications/views.py
+++ b/marketplace/applications/views.py
@@ -10,9 +10,16 @@ class AppTypeViewSet(viewsets.ViewSet):
 
     serializer_class = AppTypeSerializer
 
+    def get_serializer_context(self):
+        return {"request": self.request}
+
+    def get_serializer(self, *args, **kwargs):
+        kwargs["context"] = {"request": self.request}
+        return self.serializer_class(*args, **kwargs)
+
     def list(self, request):
         app_types = types.get_types(request.query_params.get("category"))
-        serializer = self.serializer_class(app_types, many=True)
+        serializer = self.get_serializer(app_types, many=True)
 
         return Response(serializer.data)
 
@@ -22,6 +29,6 @@ class AppTypeViewSet(viewsets.ViewSet):
         except KeyError:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-        serializer = self.serializer_class(app_type)
+        serializer = self.get_serializer(app_type)
 
         return Response(serializer.data)


### PR DESCRIPTION
The main update in this PR is the return of a new `mine` field on the endpoint that retrieves `AppTypes`. This field contains the value of the rating whose user entered in the respective `AppType`.