### PR TITLE
Add static urls when DEBUG=False

### DIFF
--- a/contrib/code_check.py
+++ b/contrib/code_check.py
@@ -33,8 +33,8 @@ def execute(cmd: str, cmd_output: bool = False):
 
 
 if __name__ == "__main__":
-    if not os.getcwd().endswith("weni-marketplace-engine"):
-        raise Exception("The command need be executed in weni-marketplace-engine")
+    if not os.getcwd().endswith("weni-integrations-engine"):
+        raise Exception("The command need be executed in weni-integrations-engine")
 
     # Lint validations
     execute("flake8 marketplace/")

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-if [ "${DEBUG}" = "false" ] ; then
-    echo "Running collectstatic"
-    python manage.py collectstatic --noinput
-fi
+echo "Running collectstatic"
+python manage.py collectstatic --noinput
 
 echo "Starting server"
 gunicorn marketplace.wsgi -c gunicorn.conf.py

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - OIDC_OP_USER_ENDPOINT=${OIDC_OP_USER_ENDPOINT}
       - OIDC_OP_JWKS_ENDPOINT=${OIDC_OP_JWKS_ENDPOINT}
       - OIDC_RP_SIGN_ALGO=${OIDC_RP_SIGN_ALGO}
+      - CONNECT_GRPC_SERVER_URL=${CONNECT_GRPC_SERVER_URL}
     depends_on:
       - database
       - redis

--- a/marketplace/urls.py
+++ b/marketplace/urls.py
@@ -1,5 +1,8 @@
+import re
+
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, re_path
+from django.views.static import serve
 from django.contrib.auth.models import Group
 from django.urls.conf import include
 from django.conf import settings
@@ -18,7 +21,17 @@ api_urls = [path("", include(applications_urls)), path("", include(interactions_
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/v1/", include(api_urls)),
-] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+]
+
+
+# Static files
+
+if settings.DEBUG:
+    urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+
+else:
+    regex_path = "^{}(?P<path>.*)$".format(re.escape(settings.STATIC_URL.lstrip("/")))
+    urlpatterns.append(re_path(regex_path, serve, {"document_root": settings.STATIC_ROOT}))
 
 
 # Django Admin


### PR DESCRIPTION
static files weren't loading in production because Django's `static` function generates URL only if `DEBUG` is set to `True`.
This pr aims to adjust this behavior.