### PR TITLE
Add permissions to comments endpoint

### DIFF
--- a/marketplace/interactions/permissions.py
+++ b/marketplace/interactions/permissions.py
@@ -1,0 +1,6 @@
+from rest_framework import permissions
+
+
+class CommentManagePermission(permissions.BasePermission):
+    def has_object_permission(self, request, view, obj):
+        return obj.created_by == request.user

--- a/marketplace/interactions/tests/test_views.py
+++ b/marketplace/interactions/tests/test_views.py
@@ -70,6 +70,11 @@ class RetrieveCommentViewTestCase(APIBaseTestCase):
         self.assertFalse(response.json["edited"])
         self.assertTrue(response.json["owned"])
 
+    def test_retrieve_with_another_user(self):
+        self.request.set_user(self.super_user)
+        response = self.request.get(self.url, apptype_pk="wwc", uuid=self.comment.uuid)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
 
 class UpdateCommentViewTestCase(APIBaseTestCase):
     view_class = CommentViewSet
@@ -98,17 +103,6 @@ class UpdateCommentViewTestCase(APIBaseTestCase):
         response = self.request.put(self.url, self.body, apptype_pk="wwc", uuid=self.comment.uuid)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    def test_modified_by_with_other_user_on_update(self):
-        created_by = self.comment.created_by
-
-        self.request.set_user(self.super_user)
-        response = self.request.put(self.url, self.body, apptype_pk="wwc", uuid=self.comment.uuid)
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertFalse(response.json["owned"])
-        self.assertNotEqual(self.comment.modified_by, created_by)
-        self.assertEqual(self.comment.created_by, created_by)
-
     def test_comment_edited_after_update(self):
         self.assertFalse(self.comment.edited)
 
@@ -127,6 +121,12 @@ class UpdateCommentViewTestCase(APIBaseTestCase):
         self.assertIn("uuid", response.json)
         self.assertIn("created_on", response.json)
         self.assertTrue(response.json["owned"])
+
+    def test_update_comment_with_another_user(self):
+        self.request.set_user(self.super_user)
+        response = self.request.put(self.url, self.body, apptype_pk="wwc", uuid=self.comment.uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
 class DestroyCommentViewTestCase(APIBaseTestCase):
@@ -156,6 +156,11 @@ class DestroyCommentViewTestCase(APIBaseTestCase):
         self.request.delete(self.url, apptype_pk="wwc", uuid=self.comment.uuid)
         self.assertFalse(Comment.objects.filter(pk=self.comment.pk).exists())
 
+    def test_destroy_comment_with_another_user(self):
+        self.request.set_user(self.super_user)
+        response = self.request.delete(self.url, apptype_pk="wwc", uuid=self.comment.uuid)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
 
 class ListCommentViewTestCase(APIBaseTestCase):
     view_class = CommentViewSet
@@ -183,6 +188,11 @@ class ListCommentViewTestCase(APIBaseTestCase):
     def test_comments_count(self):
         response = self.request.get(self.url, apptype_pk="wwc")
         self.assertEqual(len(response.json), self.comments_count)
+
+    def test_list_with_another_user(self):
+        self.request.set_user(self.super_user)
+        response = self.request.get(self.url, apptype_pk="wwc")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
 
 class CreateRatingViewTestCase(APIBaseTestCase):

--- a/marketplace/interactions/views.py
+++ b/marketplace/interactions/views.py
@@ -1,8 +1,9 @@
 from rest_framework import viewsets
 from rest_framework import mixins
 
-from marketplace.interactions.models import Comment, Rating
-from marketplace.interactions.serializers import CommentSerializer, RatingSerializer
+from .models import Comment
+from .serializers import CommentSerializer, RatingSerializer
+from .permissions import CommentManagePermission
 
 
 class CommentViewSet(viewsets.ModelViewSet):
@@ -10,6 +11,7 @@ class CommentViewSet(viewsets.ModelViewSet):
     queryset = Comment.objects
     serializer_class = CommentSerializer
     lookup_field = "uuid"
+    permission_classes = (CommentManagePermission,)
 
     def get_queryset(self):
         return super().get_queryset().filter(code=self.kwargs["apptype_pk"])


### PR DESCRIPTION
The added permission allows that update, retrieve, delete a comment only if the request user be equal to comment owner.