### PR TITLE
Adjust script that recognizes apptypes

### DIFF
--- a/marketplace/applications/tests/test_views.py
+++ b/marketplace/applications/tests/test_views.py
@@ -15,7 +15,6 @@ from marketplace.core.tests.base import APIBaseTestCase
 User = get_user_model()
 
 
-@override_settings(USE_S3=False, USE_OIDC=False)
 class AppTypeViewTestCase(APIBaseTestCase):
     def setUp(self):
         super().setUp()

--- a/marketplace/core/types/__init__.py
+++ b/marketplace/core/types/__init__.py
@@ -2,34 +2,21 @@ import os
 import inspect
 import importlib
 
+from django.utils.module_loading import import_string
 from django.conf import settings
 
 from marketplace.core.types.base import AppType
 
 
-_types = []
-
-_types_path = os.path.dirname(__file__)
+types_ = []
 
 
-def _get_modules():
-    for content_file in os.listdir(_types_path):
-        if content_file.endswith(".py") or content_file == "__pycache__":
-            continue
+def _get_app_types_members():
+    if settings.APPTYPES_CLASSES is []:
+        yield
 
-        try:
-            module = importlib.import_module(f"marketplace.core.types.{content_file}")
-        except ModuleNotFoundError:
-            continue
-
-        yield module
-
-
-def _get_app_types_members() -> list:
-    for module in _get_modules():
-        for name, member in inspect.getmembers(module):
-            if inspect.isclass(member) and issubclass(member, AppType):
-                yield member
+    for module_path in settings.APPTYPES_CLASSES:
+        yield import_string(f"marketplace.core.types.{module_path}")
 
 
 def get_types(category: str = None) -> list:
@@ -42,15 +29,17 @@ def get_types(category: str = None) -> list:
         Returns:
             list: A list of AppTypes
     """
-    global _types
+    global types_
+
+    app_types = types_.copy()
 
     if settings.DYNAMIC_APPTYPES:
-        _types += settings.DYNAMIC_APPTYPES
+        app_types += settings.DYNAMIC_APPTYPES
 
     if category:
-        return list(filter(lambda _type: _type.get_category_display() == category, _types))
+        return list(filter(lambda type_: type_.get_category_display() == category, app_types))
 
-    return _types
+    return app_types
 
 
 def get_type(code: str) -> AppType:
@@ -63,4 +52,4 @@ def get_type(code: str) -> AppType:
 
 
 for member in _get_app_types_members():
-    _types.append(member())
+    types_.append(member())

--- a/marketplace/core/types/base.py
+++ b/marketplace/core/types/base.py
@@ -84,10 +84,12 @@ class AppType(AbstractAppType):
         try:
             return self.assets.get(asset_type=AppTypeAsset.ASSET_TYPE_ICON)
         except AppTypeAsset.DoesNotExist:
-            raise AppTypeAsset.DoesNotExist(f"{self.__class__.__name__} doesn't have an icon")
+            return None
 
     def get_icon_url(self) -> str:
-        return self.get_icon_asset().attachment.url
+        icon_asset = self.get_icon_asset()
+        if icon_asset is not None:
+            return self.get_icon_asset().attachment.url
 
     def get_category_display(self) -> str:
         categories = dict(self.CATEGORY_CHOICES)

--- a/marketplace/core/types/channels/__init__.py
+++ b/marketplace/core/types/channels/__init__.py
@@ -1,1 +1,0 @@
-from .weni_web_chat.type import WeniWebChatType

--- a/marketplace/core/types/tests/test_abstract_classes.py
+++ b/marketplace/core/types/tests/test_abstract_classes.py
@@ -95,10 +95,7 @@ class AppTypeTestCase(TestCase):
 
     def test_get_icon_from_app_type_without_asset(self):
         fake_type_instance = self.FakeType()
-        message = f"{self.FakeType.__name__} doesn't have an icon"
-
-        with self.assertRaisesMessage(AppTypeAsset.DoesNotExist, message):
-            fake_type_instance.get_icon_asset()
+        self.assertIsNone(fake_type_instance.get_icon_asset())
 
     def test_get_icon_from_app_type(self):
         fake_type_instance = self.FakeType()

--- a/marketplace/core/types/urls.py
+++ b/marketplace/core/types/urls.py
@@ -7,6 +7,10 @@ urlpatterns = []
 
 for type_ in types.get_types():
     router = routers.SimpleRouter()
+
+    if type_.view_class is None:
+        continue
+
     router.register("apps", type_.view_class, basename=f"{type_.code}-app")
 
     urlpatterns.append(path(f"apptypes/{type_.code}/", include(router.urls)))

--- a/marketplace/settings.py
+++ b/marketplace/settings.py
@@ -223,6 +223,10 @@ CELERY_TIMEZONE = TIME_ZONE
 
 # Extra configurations
 
+APPTYPES_CLASSES = [
+    "channels.weni_web_chat.type.WeniWebChatType",
+]
+
 DYNAMIC_APPTYPES = []
 
 


### PR DESCRIPTION
Now, to link a new AppType on the project will be necessary to add your AppType on `APPTYPES_CLASSES`. It will no longer be automatically recognized, This allows you to modularize each app.