### PR TITLE
Add first_name and last_name in user on creating it

### DIFF
--- a/marketplace/accounts/backends.py
+++ b/marketplace/accounts/backends.py
@@ -6,6 +6,8 @@ class WeniOIDCAuthenticationBackend(OIDCAuthenticationBackend):  # pragma: no co
         email = claims.get("email")
 
         user = self.UserModel.objects.create_user(email)
+        user.first_name = claims.get("given_name", "")
+        user.last_name = claims.get("family_name", "")
         user.save()
 
         return user


### PR DESCRIPTION
`first_name` and `last_name` were coming empty when creating a new user, this PR aims to solve this problem.