### PR TITLE
Adjust first_name and last_name on create a new user

### DIFF
--- a/marketplace/accounts/backends.py
+++ b/marketplace/accounts/backends.py
@@ -2,10 +2,17 @@ from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 
 
 class WeniOIDCAuthenticationBackend(OIDCAuthenticationBackend):  # pragma: no cover
+    def filter_users_by_claims(self, claims):
+        """Return all users matching the specified email."""
+        email = claims.get("email")
+        if not email:
+            return self.UserModel.objects.none()
+        return self.UserModel.objects.filter(email__iexact=email).exclude(first_name="", last_name="")
+
     def create_user(self, claims):
         email = claims.get("email")
 
-        user = self.UserModel.objects.create_user(email)
+        user, _ = self.UserModel.objects.get_or_create(email=email)
         user.first_name = claims.get("given_name", "")
         user.last_name = claims.get("family_name", "")
         user.save()

--- a/marketplace/accounts/services.py
+++ b/marketplace/accounts/services.py
@@ -14,7 +14,7 @@ class UserPermissionService(mixins.UpdateModelMixin, generics.GenericService):
     serializer_class = ProjectAuthorizationProtoSerializer
 
     def get_object(self):
-        user = get_object_or_404(User, email=self.request.user)
+        user, _ = User.objects.get_or_create(email=self.request.user)
         project_uuid = self.request.project_uuid
         return ProjectAuthorization.objects.get_or_create(user=user, project_uuid=project_uuid)[0]
 

--- a/marketplace/settings.py
+++ b/marketplace/settings.py
@@ -48,6 +48,7 @@ ALLOWED_HOSTS = env.list("ALLOWED_HOSTS")
 INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
+    "mozilla_django_oidc",
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
@@ -60,7 +61,6 @@ INSTALLED_APPS = [
     "marketplace.grpc",
     # installed apps
     "rest_framework",
-    "mozilla_django_oidc",
     "storages",
     "corsheaders",
     "django_grpc_framework",


### PR DESCRIPTION
When creating a new user in Connect, the endpoint that updates its Integrations permissions returned 404 for an account that did not exist a user referring to that email. this PR aims to solve this problem.