### PR TITLE
Create Weni Web Chat Channel Using Generic Endpoint

### DIFF
--- a/marketplace/applications/models.py
+++ b/marketplace/applications/models.py
@@ -17,6 +17,7 @@ class App(AppTypeBaseModel):
     name: str = None
     description: str = None
     summary: str = None
+    channeltype_code: str = None
     # TODO: Add `icon` property
 
     PLATFORM_IA = "IA"
@@ -48,6 +49,7 @@ class App(AppTypeBaseModel):
         self.name = self.apptype.name
         self.description = self.apptype.description
         self.summary = self.apptype.summary
+        self.channeltype_code = self.apptype.channeltype_code
         # TODO: Add `icon` property
 
 

--- a/marketplace/core/types/base.py
+++ b/marketplace/core/types/base.py
@@ -31,6 +31,13 @@ class AbstractAppType(ABC):
         ...  # pragma: no cover
 
     @abstractproperty
+    def channeltype_code(self) -> str:
+        """
+        code referring to `ChannelType.code` in Weni Flows
+        """
+        ...
+
+    @abstractproperty
     def name(self) -> str:
         ...  # pragma: no cover
 

--- a/marketplace/core/types/channels/telegram/type.py
+++ b/marketplace/core/types/channels/telegram/type.py
@@ -7,6 +7,7 @@ class TelegramType(AppType):
     view_class = views.TelegramViewSet
 
     code = "tg"
+    channeltype_code = "TG"
     name = "Telegram"
     description = "telegram.data.description"
     summary = "telegram.data.summary"

--- a/marketplace/core/types/channels/weni_web_chat/serializers.py
+++ b/marketplace/core/types/channels/weni_web_chat/serializers.py
@@ -102,9 +102,10 @@ class ConfigSerializer(serializers.Serializer):
     def _create_channel(self) -> str:
         user = self.context.get("request").user
         name = f"{type_.WeniWebChatType.name} - #{self.app.id}"
+        data = {"name": name, "base_url": settings.SOCKET_BASE_URL}
 
         task = celery_app.send_task(
-            name="create_channel", args=[user.email, self.app.project_uuid, dict(name=name), self.app.channeltype_code]
+            name="create_channel", args=[user.email, self.app.project_uuid, data, self.app.channeltype_code]
         )
         task.wait()
 

--- a/marketplace/core/types/channels/weni_web_chat/serializers.py
+++ b/marketplace/core/types/channels/weni_web_chat/serializers.py
@@ -103,7 +103,9 @@ class ConfigSerializer(serializers.Serializer):
         user = self.context.get("request").user
         name = f"{type_.WeniWebChatType.name} - #{self.app.id}"
 
-        task = celery_app.send_task(name="create_weni_web_chat", args=[self.app.project_uuid, name, user.email])
+        task = celery_app.send_task(
+            name="create_channel", args=[user.email, self.app.project_uuid, dict(name=name), self.app.channeltype_code]
+        )
         task.wait()
 
         return task.result

--- a/marketplace/core/types/channels/weni_web_chat/type.py
+++ b/marketplace/core/types/channels/weni_web_chat/type.py
@@ -7,6 +7,7 @@ class WeniWebChatType(AppType):
     view_class = views.WeniWebChatViewSet
 
     code = "wwc"
+    channeltype_code = "WWC"
     name = "Weni Web Chat"
     description = "weniWebChat.data.description"
     summary = "weniWebChat.data.summary"

--- a/marketplace/core/types/tests/test_abstract_classes.py
+++ b/marketplace/core/types/tests/test_abstract_classes.py
@@ -21,6 +21,7 @@ class AppTypeTestCase(TestCase):
         class FakeType(AppType):  # TODO: Change name to FakeAppType
             view_class = None
             code = "ftp"
+            channeltype_code = "FTP"
             name = "Fake Type"
             description = "Type to test only"
             summary = "Type to test only"

--- a/marketplace/grpc/client.py
+++ b/marketplace/grpc/client.py
@@ -1,3 +1,5 @@
+import json
+
 import grpc
 from django.conf import settings
 
@@ -23,10 +25,12 @@ class ConnectGRPCClient:
     def _get_project_stub(self):
         return project_pb2_grpc.ProjectControllerStub(self.channel)
 
-    def create_weni_web_chat(self, project_uuid: str, name: str, user_email: str) -> str:
+    def create_channel(self, user: str, project_uuid: str, data: dict, channeltype_code: str) -> str:
+        data["base_url"] = self.base_url
+        print(dict(user=user, project_uuid=project_uuid, data=json.dumps(data), channeltype_code=channeltype_code))
         response = self.project_stub.CreateChannel(
             project_pb2.CreateChannelRequest(
-                project_uuid=project_uuid, name=name, user=user_email, base_url=self.base_url
+                user=user, project_uuid=project_uuid, data=json.dumps(data), channeltype_code=channeltype_code
             )
         )
         return response
@@ -38,10 +42,10 @@ class ConnectGRPCClient:
         return response
 
 
-@celery_app.task(name="create_weni_web_chat")
-def create_weni_web_chat(project_uuid: str, name: str, user_email: str) -> str:
+@celery_app.task(name="create_channel")
+def create_channel(user: str, project_uuid: str, data: dict, channeltype_code: str) -> str:
     client = ConnectGRPCClient()
-    return client.create_weni_web_chat(project_uuid, name, user_email).uuid
+    return client.create_channel(user, project_uuid, data, channeltype_code).uuid
 
 
 @celery_app.task(name="release_channel")

--- a/marketplace/grpc/client.py
+++ b/marketplace/grpc/client.py
@@ -26,8 +26,6 @@ class ConnectGRPCClient:
         return project_pb2_grpc.ProjectControllerStub(self.channel)
 
     def create_channel(self, user: str, project_uuid: str, data: dict, channeltype_code: str) -> str:
-        data["base_url"] = self.base_url
-        print(dict(user=user, project_uuid=project_uuid, data=json.dumps(data), channeltype_code=channeltype_code))
         response = self.project_stub.CreateChannel(
             project_pb2.CreateChannelRequest(
                 user=user, project_uuid=project_uuid, data=json.dumps(data), channeltype_code=channeltype_code

--- a/poetry.lock
+++ b/poetry.lock
@@ -731,7 +731,7 @@ python-versions = "*"
 
 [[package]]
 name = "weni-protobuffers"
-version = "1.2.1"
+version = "1.2.3"
 description = "Protocol Buffers for Weni Platform"
 category = "main"
 optional = false
@@ -1283,6 +1283,6 @@ wcwidth = [
     {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
 ]
 weni-protobuffers = [
-    {file = "weni-protobuffers-1.2.1.tar.gz", hash = "sha256:97ab25a573b8194c34cfdaaf8e1f791a4c42126922cbd23746806b69dcfae289"},
-    {file = "weni_protobuffers-1.2.1-py3-none-any.whl", hash = "sha256:a09844bc888a5a061872000160192694e9237d40b409fb60eba4ef2a225379d8"},
+    {file = "weni-protobuffers-1.2.3.tar.gz", hash = "sha256:693c5950782d441115fed21eb89693909e2b056f651382600a1cc56924d73d58"},
+    {file = "weni_protobuffers-1.2.3-py3-none-any.whl", hash = "sha256:589e0c9faa4643510240a0da7114e21bc086c7ada88c5669da46155d84b5c185"},
 ]


### PR DESCRIPTION
Main changes:
- Update weni-protobuffers to 1.2.3
- Adjust client to call the endpoint that creates a generic channel
- Create Weni Web Chat Channel Using Generic Endpoint