### PR TITLE
Improve apptypes loading system

### DIFF
--- a/marketplace/applications/tests/test_models.py
+++ b/marketplace/applications/tests/test_models.py
@@ -111,8 +111,8 @@ class TestModelAppTypeFeaturedMethods(TestCase):
         self.assertEqual(str(self.apptype_featured), self.apptype_featured.apptype.name)
 
     def test_apptype_method(self):
-        self.assertEqual(self.apptype_featured.apptype, types.get_type("wwc"))
+        self.assertEqual(self.apptype_featured.apptype, types.APPTYPES.get("wwc"))
 
     def test_get_apptype_featureds(self):
         apptype = next(self.apptype_featured.get_apptype_featureds())
-        self.assertEqual(apptype, types.get_type("wwc"))
+        self.assertEqual(apptype, types.APPTYPES.get("wwc"))

--- a/marketplace/applications/tests/test_views.py
+++ b/marketplace/applications/tests/test_views.py
@@ -42,7 +42,7 @@ class ListAppTypeViewTestCase(AppTypeViewTestCase):
 
     def test_list_app_types_count(self):
         response = self.request.get(self.url)
-        self.assertEqual(len(response.json), len(types.get_types()))
+        self.assertEqual(len(response.json), len(types.APPTYPES))
 
     def test_filter_app_type_by_fake_category(self):
         response = self.request.get(self.url + "?category=fake")
@@ -114,7 +114,7 @@ class RetrieveAppTypeViewTestCase(AppTypeViewTestCase):
         self.assertEqual(link["url"], link_asset.url)
 
     def test_retrieve_response_data(self):
-        apptype = types.get_type("wwc")
+        apptype = types.APPTYPES.get("wwc")
         response = self.request.get(self.url, pk="wwc")
         data = response.json
 

--- a/marketplace/applications/views.py
+++ b/marketplace/applications/views.py
@@ -22,18 +22,25 @@ class AppTypeViewSet(viewsets.ViewSet):
         return self.serializer_class(*args, **kwargs)
 
     def list(self, request):
-        app_types = types.get_types(request.query_params.get("category"))
-        serializer = self.get_serializer(app_types, many=True)
+        category = request.query_params.get("category", None)
+        apptypes = types.APPTYPES
+
+        if category is not None:
+            apptypes = apptypes.filter(
+                lambda apptype: apptype.get_category_display() == request.query_params.get("category")
+            )
+
+        serializer = self.get_serializer(apptypes.values(), many=True)
 
         return Response(serializer.data)
 
     def retrieve(self, request, pk=None):
         try:
-            app_type = types.get_type(pk)
+            apptype = types.APPTYPES.get(pk)
         except KeyError:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-        serializer = self.get_serializer(app_type)
+        serializer = self.get_serializer(apptype)
 
         return Response(serializer.data)
 

--- a/marketplace/core/models.py
+++ b/marketplace/core/models.py
@@ -53,7 +53,7 @@ class AppTypeBaseModel(BaseModel):
         """
         Returns the respective AppType
         """
-        return core.types.get_type(self.code)
+        return core.types.APPTYPES.get(self.code)
 
     class Meta:
         abstract = True

--- a/marketplace/core/tests/base.py
+++ b/marketplace/core/tests/base.py
@@ -1,7 +1,6 @@
 import json
 
 from django.test import TestCase
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from rest_framework.test import APIRequestFactory
 from rest_framework.test import force_authenticate
@@ -9,6 +8,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from marketplace.core.types.base import AppType
+from marketplace.core.types import APPTYPES
 
 
 User = get_user_model()
@@ -111,8 +111,8 @@ class MockDynamicAppType:
     def __enter__(self):
         for apptype in self.apptypes:
             assert isinstance(apptype, AppType), f"Expected a `AppType`, `{apptype.__class__.__name__}` is not valid!"
-            settings.DYNAMIC_APPTYPES.append(apptype)
+            APPTYPES[apptype.code] = apptype
 
     def __exit__(self, *args):
         for apptype in self.apptypes:
-            settings.DYNAMIC_APPTYPES.remove(apptype)
+            APPTYPES.pop(apptype.code)

--- a/marketplace/core/types/__init__.py
+++ b/marketplace/core/types/__init__.py
@@ -1,17 +1,28 @@
-import os
-import inspect
-import importlib
-
 from django.utils.module_loading import import_string
 from django.conf import settings
 
 from marketplace.core.types.base import AppType
 
 
-types_ = []
+class AppTypesDict(dict):
+    def get(self, code: str) -> AppType:
+        apptype = super().get(code, None)
+        if apptype is None:
+            raise KeyError(f"Invalid code: {code} No AppType found")
+        return apptype
+
+    def filter(self, function) -> dict:
+        filtered = self.__class__()
+        for key, value in self.items():
+            if function(value):
+                filtered[key] = value
+        return filtered
 
 
-def _get_app_types_members():
+APPTYPES = AppTypesDict()
+
+
+def _get_apptypes_members():
     if settings.APPTYPES_CLASSES is []:
         yield
 
@@ -19,37 +30,5 @@ def _get_app_types_members():
         yield import_string(f"marketplace.core.types.{module_path}")
 
 
-def get_types(category: str = None) -> list:
-    """
-    Returns a list of AppTypes
-
-        Parameters:
-            category (str): Filter AppTypes by category
-
-        Returns:
-            list: A list of AppTypes
-    """
-    global types_
-
-    app_types = types_.copy()
-
-    if settings.DYNAMIC_APPTYPES:
-        app_types += settings.DYNAMIC_APPTYPES
-
-    if category:
-        return list(filter(lambda type_: type_.get_category_display() == category, app_types))
-
-    return app_types
-
-
-def get_type(code: str) -> AppType:
-    types = list(filter(lambda type: type.code == code, get_types()))
-
-    if not len(types):
-        raise KeyError(f"Invalid code: {code} No AppType found")
-
-    return types[0]
-
-
-for member in _get_app_types_members():
-    types_.append(member())
+for member in _get_apptypes_members():
+    APPTYPES[member.code] = member()

--- a/marketplace/core/types/tests/test__init__.py
+++ b/marketplace/core/types/tests/test__init__.py
@@ -1,0 +1,57 @@
+from unittest import TestCase
+
+from django.conf import settings
+
+from ...types import AppTypesDict, _get_apptypes_members
+
+
+class FakeType:
+    def __init__(self, code, category, name) -> None:
+        self.code = code
+        self.category = category
+        self.name = name
+
+
+class AppTypesDictTestCase(TestCase):
+    def setUp(self):
+        self.apptypes = AppTypesDict()
+        self.apptypes["wwc"] = FakeType("wwc", "channel", "Weni Web Chat")
+        self.apptypes["tg"] = FakeType("tg", "channel", "Telegram")
+        self.apptypes["rc"] = FakeType("rc", "chat", "Rocket Chat")
+
+    def test_get_method_returns_right_apptype(self):
+        self.assertEqual(self.apptypes.get("wwc").code, "wwc")
+
+    def test_get_method_raises_key_error(self):
+        with self.assertRaises(KeyError):
+            self.apptypes.get("wrong")
+
+    def test_filter_method_returns_apptype_dict(self):
+        def filter_(apptype):
+            return apptype.category == "channel"
+
+        self.assertEqual(type(self.apptypes.filter(filter_)), AppTypesDict)
+
+    def test_len_from_filter_method_with_channel_category(self):
+        def filter_(apptype):
+            return apptype.category == "channel"
+
+        self.assertEqual(len(self.apptypes.filter(filter_)), 2)
+
+    def test_len_from_filter_method_with_chat_category(self):
+        def filter_(apptype):
+            return apptype.category == "chat"
+
+        self.assertEqual(len(self.apptypes.filter(filter_)), 1)
+
+    def test_len_from_filter_method_with_wrong_category(self):
+        def filter_(apptype):
+            return apptype.category == "wrong"
+
+        self.assertEqual(len(self.apptypes.filter(filter_)), 0)
+
+
+class FunctionsTestCase(TestCase):
+    def test_get_app_types_members(self):
+        members = list(_get_apptypes_members())
+        self.assertEqual(len(members), len(settings.APPTYPES_CLASSES))

--- a/marketplace/core/types/urls.py
+++ b/marketplace/core/types/urls.py
@@ -5,12 +5,11 @@ from marketplace.core import types
 
 urlpatterns = []
 
-for type_ in types.get_types():
+for apptype in types.APPTYPES.values():
     router = routers.SimpleRouter()
-
-    if type_.view_class is None:
+    if apptype.view_class is None:
         continue
 
-    router.register("apps", type_.view_class, basename=f"{type_.code}-app")
+    router.register("apps", apptype.view_class, basename=f"{apptype.code}-app")
 
-    urlpatterns.append(path(f"apptypes/{type_.code}/", include(router.urls)))
+    urlpatterns.append(path(f"apptypes/{apptype.code}/", include(router.urls)))

--- a/marketplace/core/validators.py
+++ b/marketplace/core/validators.py
@@ -5,6 +5,6 @@ def validate_app_code_exists(value):
     from marketplace.core import types
 
     try:
-        types.get_type(value)
+        types.APPTYPES.get(value)
     except KeyError:
         raise ValidationError(f"AppType ({value}) not exists!")

--- a/marketplace/settings.py
+++ b/marketplace/settings.py
@@ -233,8 +233,6 @@ APPTYPES_CLASSES = [
     "channels.telegram.type.TelegramType",
 ]
 
-DYNAMIC_APPTYPES = []
-
 
 # Sentry configuration
 


### PR DESCRIPTION
This PR aims to improve the apptypes loading system by removing unnecessary complexity.

Main changes:
- Create a new class named `AppTypesDict` that inherits from dict and override `filter` and `get` method;
- Cover the new `AppTypesDict`  class with tests;
- Adjust tests, views, models, validators to use the new class;
- Remove `DYNAMIC_APPTYPES` from `settings.py` cause did it become deprecated.