### PR TITLE
Add new field to Weni Web Chat app called tooltipMessage

### DIFF
--- a/marketplace/core/types/channels/weni_web_chat/serializers.py
+++ b/marketplace/core/types/channels/weni_web_chat/serializers.py
@@ -42,6 +42,7 @@ class ConfigSerializer(serializers.Serializer):
     profileAvatar = AvatarBase64ImageField(required=False)
     customCss = serializers.CharField(required=False)
     timeBetweenMessages = serializers.IntegerField(default=1)
+    tooltipMessage = serializers.CharField(required=False)
 
     def to_internal_value(self, data):
         self.app = self.parent.instance


### PR DESCRIPTION
Main change:
- Add a new field to the Weni Web Chat app called `tooltipMessage` with required equals to `False`