### PR TITLE
Add task that syncs whatsapp channels from flows

### DIFF
--- a/marketplace/celery.py
+++ b/marketplace/celery.py
@@ -6,9 +6,18 @@ from celery import Celery
 from marketplace import settings
 
 
+def get_extra_task_paths() -> list:
+    types_path = "marketplace.core.types."
+    extra_task_paths = ["marketplace.grpc.client"]
+    for apptype in settings.APPTYPES_CLASSES:
+        extra_task_paths.append(types_path + ".".join(apptype.split(".")[:2]))
+    return extra_task_paths
+
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "marketplace.settings")
 
 app = Celery("marketplace")
 
 app.config_from_object("django.conf:settings", namespace="CELERY")
-app.autodiscover_tasks(settings.INSTALLED_APPS + ["marketplace.grpc.client"])
+app.conf.beat_schedule = settings.CELERY_BEAT_SCHEDULE
+app.autodiscover_tasks(settings.INSTALLED_APPS + get_extra_task_paths())

--- a/marketplace/core/types/channels/whatsapp/tasks.py
+++ b/marketplace/core/types/channels/whatsapp/tasks.py
@@ -1,0 +1,54 @@
+import json
+import logging
+
+from django.conf import settings
+from django_redis import get_redis_connection
+
+from marketplace.celery import app as celery_app
+from marketplace.grpc.client import ConnectGRPCClient
+from marketplace.core.types import APPTYPES
+from marketplace.applications.models import App
+
+from django.contrib.auth import get_user_model
+
+
+User = get_user_model()
+logger = logging.getLogger(__name__)
+
+
+SYNC_WHATSAPP_LOCK_KEY = "sync-whatsapp-lock"
+
+
+@celery_app.task(name="sync_whatsapp_apps")
+def sync_whatsapp_apps():
+    apptype = APPTYPES.get("wpp")
+    response = ConnectGRPCClient().list_channels(apptype.channeltype_code)
+
+    redis = get_redis_connection()
+
+    if redis.get(SYNC_WHATSAPP_LOCK_KEY):
+        logger.info("The apps are already syncing by another task!")
+        return None
+
+    else:
+        with redis.lock(SYNC_WHATSAPP_LOCK_KEY):
+            for channel in response:
+                channel_config = json.loads(channel.config)
+
+                # Skipping WhatsApp demo channels, change to environment variable later
+                if "558231420933" in channel.address:
+                    continue
+
+                config = {"title": channel.address}
+                config.update(channel_config)
+
+                app, created = App.objects.get_or_create(
+                    code=apptype.code,
+                    platform=apptype.platform,
+                    project_uuid=channel.project_uuid,
+                    flow_channel=channel.uuid,
+                    defaults=dict(config=config, created_by=User.objects.get_admin_user()),
+                )
+
+                if created:
+                    logger.info(f"A new whatsapp app was created automatically. UUID: {app.uuid}")

--- a/marketplace/settings.py
+++ b/marketplace/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 
 import os
 from pathlib import Path
+from datetime import timedelta
 
 import environ
 import sentry_sdk
@@ -222,16 +223,33 @@ FLOWS_HOST_URL = env.str("FLOWS_HOST_URL", "")
 
 ROUTER_GRPC_SERVER_URL = env.str("ROUTER_GRPC_SERVER_URL")
 ROUTER_CERTIFICATE_GRPC_CRT = env.str("ROUTER_CERTIFICATE_GRPC_CRT", None)
+ROUTER_BASE_URL = env.str("ROUTER_BASE_URL")
+
+
+# Redis
+
+REDIS_URL = env.str("REDIS_URL", default="redis://localhost:6379")
 
 
 # Celery
 
-CELERY_BROKER_URL = env.str("CELERY_BROKER_URL", default="redis://localhost:6379")
+CELERY_BROKER_URL = env.str("CELERY_BROKER_URL", default=REDIS_URL)
 CELERY_RESULT_BACKEND = env.str("CELERY_RESULT_BACKEND", default="redis://localhost:6379")
 CELERY_ACCEPT_CONTENT = ["application/json"]
 CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
 CELERY_TIMEZONE = TIME_ZONE
+
+
+# Cache
+
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": REDIS_URL,
+        "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
+    }
+}
 
 
 # Extra configurations
@@ -266,4 +284,4 @@ USE_GRPC = env.bool("USE_GRPC", default=False)
 
 # Celery
 
-CELERY_BEAT_SCHEDULE = {}
+CELERY_BEAT_SCHEDULE = {"sync-whatsapp-apps": {"task": "sync_whatsapp_apps", "schedule": timedelta(hours=2)}}

--- a/marketplace/settings.py
+++ b/marketplace/settings.py
@@ -234,7 +234,7 @@ REDIS_URL = env.str("REDIS_URL", default="redis://localhost:6379")
 # Celery
 
 CELERY_BROKER_URL = env.str("CELERY_BROKER_URL", default=REDIS_URL)
-CELERY_RESULT_BACKEND = env.str("CELERY_RESULT_BACKEND", default="redis://localhost:6379")
+CELERY_RESULT_BACKEND = env.str("CELERY_RESULT_BACKEND", default=REDIS_URL)
 CELERY_ACCEPT_CONTENT = ["application/json"]
 CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"

--- a/marketplace/settings.py
+++ b/marketplace/settings.py
@@ -262,3 +262,8 @@ GRPC_FRAMEWORK = {
 }
 
 USE_GRPC = env.bool("USE_GRPC", default=False)
+
+
+# Celery
+
+CELERY_BEAT_SCHEDULE = {}

--- a/poetry.lock
+++ b/poetry.lock
@@ -281,6 +281,21 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "django-redis"
+version = "5.2.0"
+description = "Full featured redis cache backend for Django."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+Django = ">=2.2"
+redis = ">=3,<4.0.0 || >4.0.0,<4.0.1 || >4.0.1"
+
+[package.extras]
+hiredis = ["redis[hiredis] (>=3,!=4.0.0,!=4.0.1)"]
+
+[[package]]
 name = "django-storages"
 version = "1.12.2"
 description = "Support for many storage backends in Django"
@@ -752,7 +767,7 @@ protobuf = ">=3.17.3,<4.0.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "63eb20d35c9531cd4b813bffe2d26411eafb30a10bff10979cd526cea80100ed"
+content-hash = "6d3f9f1492e50c5b45f99a2264fb50e0e771472bcc2657eea9d59311b6d36d2f"
 
 [metadata.files]
 amqp = [
@@ -946,6 +961,10 @@ django-cors-headers = [
 django-environ = [
     {file = "django-environ-0.4.5.tar.gz", hash = "sha256:6c9d87660142608f63ec7d5ce5564c49b603ea8ff25da595fd6098f6dc82afde"},
     {file = "django_environ-0.4.5-py2.py3-none-any.whl", hash = "sha256:c57b3c11ec1f319d9474e3e5a79134f40174b17c7cc024bbb2fad84646b120c4"},
+]
+django-redis = [
+    {file = "django-redis-5.2.0.tar.gz", hash = "sha256:8a99e5582c79f894168f5865c52bd921213253b7fd64d16733ae4591564465de"},
+    {file = "django_redis-5.2.0-py3-none-any.whl", hash = "sha256:1d037dc02b11ad7aa11f655d26dac3fb1af32630f61ef4428860a2e29ff92026"},
 ]
 django-storages = [
     {file = "django-storages-1.12.2.tar.gz", hash = "sha256:0013ebe4904521e2fa28f33591a03a7210304d73363e7eadd7cdcf81c12ba003"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ grpcio-tools = "^1.40.0"
 djangogrpcframework = "^0.2.1"
 weni-protobuffers = "^1.2.0"
 python-decouple = "^3.5"
+django-redis = "^5.2.0"
 
 [tool.poetry.dev-dependencies]
 black = "^21.5b2"


### PR DESCRIPTION
Main changes:
- Adds support for tasks in each apptype, this allows each apptype to have completely independent tasks;
- Adds task that retrieves all WhatsApp channels from flows creates an app referring to it;
- Add a package as a dependency so you can use redis;
- Add x environment variables:
  - `ROUTER_BASE_URL`
  - `REDIS_URL`