### PR TITLE
Remove option that ignores F401

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,4 @@
 [flake8]
-ignore = F401
 exclude = 
     .git,
     __pycache__,

--- a/marketplace/accounts/services.py
+++ b/marketplace/accounts/services.py
@@ -1,4 +1,3 @@
-from django.shortcuts import get_object_or_404
 from django_grpc_framework import generics, mixins
 from django.contrib.auth import get_user_model
 

--- a/marketplace/applications/models.py
+++ b/marketplace/applications/models.py
@@ -6,7 +6,6 @@ from django.db.models.constraints import UniqueConstraint
 from django.utils.translation import ugettext_lazy as _
 
 from marketplace.core.models import AppTypeBaseModel
-from marketplace import core
 
 if TYPE_CHECKING:
     from marketplace.core.types.base import AppType

--- a/marketplace/applications/serializers.py
+++ b/marketplace/applications/serializers.py
@@ -2,7 +2,6 @@ from marketplace.applications.models import App, AppTypeAsset
 from marketplace.interactions.models import Rating
 from rest_framework import serializers
 from marketplace.core.types.base import AppType
-from marketplace.core import types
 
 
 class AppTypeSerializer(serializers.Serializer):

--- a/marketplace/applications/tests/test_views.py
+++ b/marketplace/applications/tests/test_views.py
@@ -1,6 +1,5 @@
 import uuid
 
-from django.test import override_settings
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 from rest_framework import status

--- a/marketplace/core/tests/test_fields.py
+++ b/marketplace/core/tests/test_fields.py
@@ -1,5 +1,3 @@
-import uuid
-
 from django.test import TestCase
 from django.core.files.base import ContentFile
 from rest_framework import serializers

--- a/marketplace/core/types/channels/telegram/serializers.py
+++ b/marketplace/core/types/channels/telegram/serializers.py
@@ -3,7 +3,6 @@ from rest_framework import serializers
 from marketplace.core.serializers import AppTypeBaseSerializer
 from marketplace.applications.models import App
 from marketplace.celery import app as celery_app
-from . import type as type_
 
 
 class TelegramSerializer(AppTypeBaseSerializer):

--- a/marketplace/core/types/channels/whatsapp/tasks.py
+++ b/marketplace/core/types/channels/whatsapp/tasks.py
@@ -1,7 +1,6 @@
 import json
 import logging
 
-from django.conf import settings
 from django_redis import get_redis_connection
 
 from marketplace.celery import app as celery_app

--- a/marketplace/core/types/channels/whatsapp_demo/views.py
+++ b/marketplace/core/types/channels/whatsapp_demo/views.py
@@ -1,6 +1,3 @@
-from rest_framework.decorators import action
-from rest_framework.response import Response
-
 from marketplace.core.types import views
 from .serializers import WhatsAppDemoSerializer
 from marketplace.celery import app as celery_app

--- a/marketplace/grpc/urls.py
+++ b/marketplace/grpc/urls.py
@@ -1,4 +1,3 @@
-from django_grpc_framework import services
 from marketplace.accounts.urls import grpc_handlers as accounts_grpc_handlers
 
 

--- a/marketplace/interactions/tests/test_views.py
+++ b/marketplace/interactions/tests/test_views.py
@@ -1,5 +1,4 @@
 from django.urls import reverse
-from django.contrib.auth import get_user_model
 from rest_framework import status
 
 from marketplace.core.tests.base import APIBaseTestCase


### PR DESCRIPTION
The purpose of this PR is to remove the option that ignores F401 from flake8, this caused flake8 to ignore unused imports