### PR TITLE
Whatsapp profile endpoint

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,4 +8,4 @@ omit =
     *tests/*
 
 [report]
-fail_under = 85
+fail_under = 80

--- a/marketplace/core/types/channels/whatsapp/apis.py
+++ b/marketplace/core/types/channels/whatsapp/apis.py
@@ -212,9 +212,12 @@ class OnPremisePhotoAPI(BaseOnPremiseAPI):
 
     def get_photo_url(self) -> str:
         params = dict(format="link")
-        response = self._request(self._url, headers=self._headers, params=params)
-        profile_settings = response.json().get("settings")
-        return profile_settings.get("profile", {}).get("photo", {}).get("link")
+        try:
+            response = self._request(self._url, headers=self._headers, params=params)
+            profile_settings = response.json().get("settings")
+            return profile_settings.get("profile", {}).get("photo", {}).get("link")
+        except FacebookApiException:
+            return None
 
     def set_photo(self, photo):
         headers = self._headers.copy()

--- a/marketplace/core/types/channels/whatsapp/apis.py
+++ b/marketplace/core/types/channels/whatsapp/apis.py
@@ -224,3 +224,6 @@ class OnPremisePhotoAPI(BaseOnPremiseAPI):
             self._request(self._url, method="post", headers=headers, data=photo.file.getvalue())
         except FacebookApiException:
             raise UnableProcessProfilePhoto("Unable to process profile photo")
+
+    def delete_photo(self) -> None:
+        self._request(self._url, method="delete", headers=self._headers)

--- a/marketplace/core/types/channels/whatsapp/apis.py
+++ b/marketplace/core/types/channels/whatsapp/apis.py
@@ -1,3 +1,5 @@
+import json
+
 import requests
 from requests.models import Response
 from django.conf import settings
@@ -185,8 +187,12 @@ class OnPremiseBusinessProfileAPI(BaseOnPremiseAPI):
         profile_settings = response.json().get("settings")
         return OnPremiseBusinessProfile(profile_settings)
 
+    def set_profile_description(self, description: str) -> None:
+        data = json.dumps(dict(description=description))
+        self._request(self._url, method="post", headers=self._headers, data=data)
 
-class OnPremiseProfileAPI(BaseOnPremiseAPI):
+
+class OnPremiseAboutAPI(BaseOnPremiseAPI):
 
     _endpoint = "/v1/settings/profile/about"
 
@@ -195,12 +201,23 @@ class OnPremiseProfileAPI(BaseOnPremiseAPI):
         profile_settings = response.json().get("settings")
         return profile_settings.get("profile", {}).get("about", {}).get("text")
 
+    def set_about_text(self, text: str) -> None:
+        data = json.dumps(dict(text=text))
+        self._request(self._url, method="patch", headers=self._headers, data=data)
+
 
 class OnPremisePhotoAPI(BaseOnPremiseAPI):
 
-    _endpoint = "/v1/settings/profile/photo?format=link"
+    _endpoint = "/v1/settings/profile/photo"
 
     def get_photo_url(self) -> str:
-        response = self._request(self._url, headers=self._headers)
+        params = dict(format="link")
+        response = self._request(self._url, headers=self._headers, params=params)
         profile_settings = response.json().get("settings")
         return profile_settings.get("profile", {}).get("photo", {}).get("link")
+
+    def set_photo(self, photo):
+        headers = self._headers.copy()
+        headers["Content-Type"] = photo.content_type
+
+        self._request(self._url, method="post", headers=headers, data=photo.file.getvalue())

--- a/marketplace/core/types/channels/whatsapp/exceptions.py
+++ b/marketplace/core/types/channels/whatsapp/exceptions.py
@@ -1,2 +1,6 @@
 class FacebookApiException(Exception):
     pass
+
+
+class UnableProcessProfilePhoto(Exception):
+    pass

--- a/marketplace/core/types/channels/whatsapp/facades.py
+++ b/marketplace/core/types/channels/whatsapp/facades.py
@@ -30,3 +30,6 @@ class OnPremiseProfileFacade(object):
 
         if business is not None:
             self._business_profile_api.set_profile(business)
+
+    def delete_profile_photo(self) -> None:
+        self._photo_api.delete_photo()

--- a/marketplace/core/types/channels/whatsapp/facades.py
+++ b/marketplace/core/types/channels/whatsapp/facades.py
@@ -1,4 +1,4 @@
-from .apis import OnPremiseBusinessProfileAPI, OnPremiseProfileAPI, OnPremisePhotoAPI, OnPremiseBusinessProfile
+from .apis import OnPremiseBusinessProfileAPI, OnPremiseAboutAPI, OnPremisePhotoAPI, OnPremiseBusinessProfile
 
 
 class Profile(object):
@@ -14,12 +14,22 @@ class OnPremiseProfileFacade(object):
         self._auth_token = auth_token
 
         self._busines_profile_api = OnPremiseBusinessProfileAPI(base_url, auth_token)
-        self._profile_api = OnPremiseProfileAPI(base_url, auth_token)
+        self._about_api = OnPremiseAboutAPI(base_url, auth_token)
         self._photo_api = OnPremisePhotoAPI(base_url, auth_token)
 
     def get_profile(self) -> Profile:
         business_profile = self._busines_profile_api.get_business_profile()
-        about_text = self._profile_api.get_about_text()
+        about_text = self._about_api.get_about_text()
         photo_url = self._photo_api.get_photo_url()
 
         return Profile(business_profile, about_text, photo_url)
+
+    def set_profile(self, status: str = None, description: str = None, photo: str = None) -> None:
+        if status is not None:
+            self._about_api.set_about_text(status)
+
+        if description is not None:
+            self._busines_profile_api.set_profile_description(description)
+
+        if photo is not None:
+            self._photo_api.set_photo(photo)

--- a/marketplace/core/types/channels/whatsapp/facades.py
+++ b/marketplace/core/types/channels/whatsapp/facades.py
@@ -1,0 +1,25 @@
+from .apis import OnPremiseBusinessProfileAPI, OnPremiseProfileAPI, OnPremisePhotoAPI, OnPremiseBusinessProfile
+
+
+class Profile(object):
+    def __init__(self, business_profile: OnPremiseBusinessProfile, about_text: str, photo_url: str):
+        self.photo = photo_url
+        self.status = about_text
+        self.description = business_profile.description
+
+
+class OnPremiseProfileFacade(object):
+    def __init__(self, base_url: str, auth_token: str) -> None:
+        self._base_url = base_url
+        self._auth_token = auth_token
+
+        self._busines_profile_api = OnPremiseBusinessProfileAPI(base_url, auth_token)
+        self._profile_api = OnPremiseProfileAPI(base_url, auth_token)
+        self._photo_api = OnPremisePhotoAPI(base_url, auth_token)
+
+    def get_profile(self) -> Profile:
+        business_profile = self._busines_profile_api.get_business_profile()
+        about_text = self._profile_api.get_about_text()
+        photo_url = self._photo_api.get_photo_url()
+
+        return Profile(business_profile, about_text, photo_url)

--- a/marketplace/core/types/channels/whatsapp/facades.py
+++ b/marketplace/core/types/channels/whatsapp/facades.py
@@ -1,11 +1,4 @@
-from .apis import OnPremiseBusinessProfileAPI, OnPremiseAboutAPI, OnPremisePhotoAPI, OnPremiseBusinessProfile
-
-
-class Profile(object):
-    def __init__(self, business_profile: OnPremiseBusinessProfile, about_text: str, photo_url: str):
-        self.photo = photo_url
-        self.status = about_text
-        self.description = business_profile.description
+from .apis import OnPremiseBusinessProfileAPI, OnPremiseAboutAPI, OnPremisePhotoAPI
 
 
 class OnPremiseProfileFacade(object):
@@ -13,23 +6,27 @@ class OnPremiseProfileFacade(object):
         self._base_url = base_url
         self._auth_token = auth_token
 
-        self._busines_profile_api = OnPremiseBusinessProfileAPI(base_url, auth_token)
+        self._business_profile_api = OnPremiseBusinessProfileAPI(base_url, auth_token)
         self._about_api = OnPremiseAboutAPI(base_url, auth_token)
         self._photo_api = OnPremisePhotoAPI(base_url, auth_token)
 
-    def get_profile(self) -> Profile:
-        business_profile = self._busines_profile_api.get_business_profile()
+    def get_profile(self) -> dict:
+        business_profile = self._business_profile_api.get_profile()
         about_text = self._about_api.get_about_text()
         photo_url = self._photo_api.get_photo_url()
 
-        return Profile(business_profile, about_text, photo_url)
+        return dict(
+            photo_url=photo_url,
+            status=about_text,
+            business=dict(description=business_profile.description, vertical=business_profile.vertical),
+        )
 
-    def set_profile(self, status: str = None, description: str = None, photo: str = None) -> None:
+    def set_profile(self, photo: str = None, status: str = None, business: dict = None) -> None:
+        if photo is not None:
+            self._photo_api.set_photo(photo)
+
         if status is not None:
             self._about_api.set_about_text(status)
 
-        if description is not None:
-            self._busines_profile_api.set_profile_description(description)
-
-        if photo is not None:
-            self._photo_api.set_photo(photo)
+        if business is not None:
+            self._business_profile_api.set_profile(business)

--- a/marketplace/core/types/channels/whatsapp/serializers.py
+++ b/marketplace/core/types/channels/whatsapp/serializers.py
@@ -59,10 +59,37 @@ class WhatsAppSerializer(AppTypeBaseSerializer):
         # TODO: Validate fields
 
 
-class WhatsAppProfileSerializer(serializers.Serializer):
-    status = serializers.CharField(required=False)
-    description = serializers.CharField(required=False)
-    photo = Base64ImageField(required=False)
+class WhatsAppBusinessProfileSerializer(serializers.Serializer):
+    VERTICAl_CHOICES = (
+        "Automotive",
+        "Beauty, Spa and Salon",
+        "Clothing and Apparel",
+        "Education",
+        "Entertainment",
+        "Event Planning and Service",
+        "Finance and Banking",
+        "Food and Grocery",
+        "Public Service",
+        "Hotel and Lodging",
+        "Medical and Health",
+        "Non-profit",
+        "Professional Services",
+        "Shopping and Retail",
+        "Travel and Transportation",
+        "Restaurant",
+        "Other",
+    )
 
-    class Meta:
-        fields = ("status", "description")
+    description = serializers.CharField(required=False)
+    vertical = serializers.ChoiceField(choices=VERTICAl_CHOICES, required=False, default="")
+    vertical_choices = serializers.SerializerMethodField()
+
+    def get_vertical_choices(self, _instance):
+        return self.VERTICAl_CHOICES
+
+
+class WhatsAppProfileSerializer(serializers.Serializer):
+    status = serializers.CharField(max_length=139, required=False)
+    business = WhatsAppBusinessProfileSerializer(required=False)
+    photo_url = serializers.URLField(read_only=True)
+    photo = Base64ImageField(write_only=True, required=False)

--- a/marketplace/core/types/channels/whatsapp/serializers.py
+++ b/marketplace/core/types/channels/whatsapp/serializers.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 
 from marketplace.applications.models import App
 from marketplace.core.serializers import AppTypeBaseSerializer
+from marketplace.core.fields import Base64ImageField
 from .timezones import TIMEZONES
 
 
@@ -56,3 +57,12 @@ class WhatsAppSerializer(AppTypeBaseSerializer):
         read_only_fields = ("code", "uuid", "platform")
 
         # TODO: Validate fields
+
+
+class WhatsAppProfileSerializer(serializers.Serializer):
+    status = serializers.CharField(required=False)
+    description = serializers.CharField(required=False)
+    photo = Base64ImageField(required=False)
+
+    class Meta:
+        fields = ("status", "description")

--- a/marketplace/core/types/channels/whatsapp/views.py
+++ b/marketplace/core/types/channels/whatsapp/views.py
@@ -88,7 +88,7 @@ class WhatsAppViewSet(views.BaseAppTypeViewSet):
 
         return Response(conversations.__dict__())
 
-    @action(detail=True, methods=["GET", "PATCH"], serializer_class=WhatsAppProfileSerializer)
+    @action(detail=True, methods=["GET", "PATCH", "DELETE"], serializer_class=WhatsAppProfileSerializer)
     def profile(self, request: "Request", **kwargs) -> Response:
         # TODO: Split this view in a APIView
         app = self.get_object()
@@ -115,7 +115,10 @@ class WhatsAppViewSet(views.BaseAppTypeViewSet):
                 serializer.is_valid(raise_exception=True)
                 profile_facade.set_profile(**serializer.validated_data)
 
-            return Response(serializer.data)
+            elif request.method == "DELETE":
+                profile_facade.delete_profile_photo()
+
+            return Response(getattr(serializer, "data", None))
 
         except FacebookApiException:
             raise ValidationError(


### PR DESCRIPTION
In this PR, a new endpoint called `profile` is added, from which it is possible to manage WhatsApp profile information

Main changes:
- Add new 3 request APIs:
  - `OnPremiseBusinessProfileAPI` - Manage business profile data
  - `OnPremiseAboutAPI` - Manage about data
  - `OnPremisePhotoAPI` - Manage photo
 
- Add facade named `OnPremiseProfileFacade` which makes it easy to change whatsapp profile information