### PR TITLE
feat: add coexistence integration support for WhatsApp Cloud

### DIFF
--- a/marketplace/clients/facebook/client.py
+++ b/marketplace/clients/facebook/client.py
@@ -657,6 +657,14 @@ class BusinessMetaRequests(
         response = self.make_request(url, method="POST", headers=headers, data=data)
         return response.json()
 
+    def sync_coexistence_history(self, phone_number_id: str) -> dict:
+        url = f"{self.get_url}/{phone_number_id}/smb_app_data"
+        data = {"messaging_product": "whatsapp", "sync_type": "smb_app_state_sync"}
+        response = self.make_request(
+            url, method="POST", headers=self._get_headers(), data=data
+        )
+        return response.json()
+
 
 class FacebookClient(
     CatalogsRequests,

--- a/marketplace/clients/facebook/client.py
+++ b/marketplace/clients/facebook/client.py
@@ -657,7 +657,7 @@ class BusinessMetaRequests(
         response = self.make_request(url, method="POST", headers=headers, data=data)
         return response.json()
 
-    def sync_coexistence_history(self, phone_number_id: str) -> dict:
+    def sync_coexistence_contacts(self, phone_number_id: str) -> dict:
         url = f"{self.get_url}/{phone_number_id}/smb_app_data"
         data = {"messaging_product": "whatsapp", "sync_type": "smb_app_state_sync"}
         response = self.make_request(

--- a/marketplace/core/types/channels/whatsapp_cloud/serializers.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/serializers.py
@@ -24,6 +24,14 @@ class WhatsAppCloudSerializer(AppTypeBaseSerializer):
 
 
 class WhatsAppCloudConfigureSerializer(serializers.Serializer):
+    INTEGRATION_TYPE_CHOICES = (
+        ("default", "Default"),
+        ("coexistence", "Coexistence"),
+    )
+
     waba_id = serializers.CharField(required=True)
     phone_number_id = serializers.CharField(required=True)
     auth_code = serializers.CharField(required=True)
+    integration_type = serializers.ChoiceField(
+        choices=INTEGRATION_TYPE_CHOICES, default="default"
+    )

--- a/marketplace/services/facebook/service.py
+++ b/marketplace/services/facebook/service.py
@@ -326,9 +326,9 @@ class TemplateService:
                 translation=returned_translation,
                 button_type=button["type"],
                 url=button["url"]["base_url"] if "url" in button else None,
-                example=button["url"]["url_suffix_example"]
-                if "url" in button
-                else None,
+                example=(
+                    button["url"]["url_suffix_example"] if "url" in button else None
+                ),
                 text=button.get("text", ""),
                 phone_number=None,
             )
@@ -453,3 +453,6 @@ class BusinessMetaService:
             "message_template_namespace": message_template_namespace,
             "allocation_config_id": allocation_config_id,
         }
+
+    def sync_coexistence_contacts(self, phone_number_id: str) -> Dict[str, Any]:
+        return self.client.sync_coexistence_contacts(phone_number_id)

--- a/marketplace/services/facebook/tests/test_services.py
+++ b/marketplace/services/facebook/tests/test_services.py
@@ -169,6 +169,9 @@ class MockClient:
             "category": template_data.get("category", "UTILITY"),
         }
 
+    def sync_coexistence_contacts(self, phone_number_id):
+        return {"success": True}
+
 
 class TestFacebookService(TestCase):
     def generate_unique_facebook_catalog_id(self):
@@ -682,3 +685,7 @@ class TestBusinessMetaService(TestCase):
                 "allocation_config_id": "mock_allocation_id",
             },
         )
+
+    def test_sync_coexistence_contacts(self):
+        response = self.service.sync_coexistence_contacts("phone_number_id")
+        self.assertEqual(response, {"success": True})


### PR DESCRIPTION
- Introduced `sync_coexistence_history` method in Facebook client to sync SMB app data.
- Updated WhatsAppCloudConfigureSerializer to include `integration_type` field with choices for "default" and "coexistence".
- Modified WhatsAppCloudViewSet to handle phone number registration based on integration type and sync contacts for coexistence integration.