### PR TITLE
fix: remove webhook log and update sku validator timeout

### DIFF
--- a/marketplace/settings.py
+++ b/marketplace/settings.py
@@ -508,4 +508,4 @@ except FileNotFoundError:
     JWT_PUBLIC_KEY = None
 
 # SKU Validator timeout
-SKU_VALIDATOR_TIMEOUT = env.int("SKU_VALIDATOR_TIMEOUT", default=86400)
+SKU_VALIDATOR_TIMEOUT = env.int("SKU_VALIDATOR_TIMEOUT", default=1200)

--- a/marketplace/wpp_products/tasks.py
+++ b/marketplace/wpp_products/tasks.py
@@ -299,8 +299,8 @@ def send_sync(app_uuid: str, webhook: dict):
     # Check if the app uses specific queue
     celery_queue = app.config.get("celery_queue_name", "product_synchronization")
 
-    # Webhook Log
-    WebhookLog.objects.create(sku_id=sku_id, data=webhook, vtex_app=app)
+    # Commented out on 2025-07-16 to reduce database writes
+    # WebhookLog.objects.create(sku_id=sku_id, data=webhook, vtex_app=app)
 
     logger.info(f"App {app_uuid} uses Sync v2. Enqueuing for batch update.")
 


### PR DESCRIPTION
- Changed SKU_VALIDATOR_TIMEOUT default value from 86400 to 1200 seconds.
- Introduced cache key generation and caching validation methods in SKUValidator class to enhance performance.
- Commented out WebhookLog creation to reduce database writes.