### PR TITLE
fix: Preserve WWC config fields not sent on PATCH configure

### DIFF
--- a/marketplace/core/types/channels/weni_web_chat/serializers.py
+++ b/marketplace/core/types/channels/weni_web_chat/serializers.py
@@ -114,8 +114,26 @@ class ConfigSerializer(serializers.Serializer):
     )
     voiceMode = serializers.JSONField(required=False)
 
+    @staticmethod
+    def _is_stored_url(value):
+        return isinstance(value, str) and value.startswith(("http://", "https://"))
+
+    def _merge_with_existing_config(self, incoming_data):
+        """Merge incoming PATCH data with existing config to preserve unset fields."""
+        existing_config = self.app.config
+        merged = {}
+        for field_name in self.fields:
+            if field_name in incoming_data:
+                merged[field_name] = incoming_data[field_name]
+            elif field_name in existing_config:
+                merged[field_name] = existing_config[field_name]
+        return merged
+
     def to_internal_value(self, data):
         self.app = self.parent.instance
+
+        if self.app and self.app.config:
+            data = self._merge_with_existing_config(data)
 
         data = super().to_internal_value(data)
         storage = AppStorage(self.app)
@@ -135,9 +153,11 @@ class ConfigSerializer(serializers.Serializer):
                     data["openLauncherImage"] = storage.url(up_file.name)
 
         if data.get("customCss"):
-            with storage.open("custom.css", "w") as up_file:
-                up_file.write(data["customCss"])
-                data["customCss"] = storage.url(up_file.name)
+            custom_css = data["customCss"]
+            if not self._is_stored_url(custom_css):
+                with storage.open("custom.css", "w") as up_file:
+                    up_file.write(custom_css)
+                    data["customCss"] = storage.url(up_file.name)
 
         return data
 

--- a/marketplace/core/types/channels/weni_web_chat/tests/test_views.py
+++ b/marketplace/core/types/channels/weni_web_chat/tests/test_views.py
@@ -379,9 +379,7 @@ class ConfigureWeniWebChatTestCase(PermissionTestCaseMixin, APIBaseTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.app.refresh_from_db()
-        self.assertEqual(
-            self.app.config["conversationStarters"]["pdp"], True
-        )
+        self.assertEqual(self.app.config["conversationStarters"]["pdp"], True)
 
     @patch("marketplace.core.types.channels.weni_web_chat.serializers.FlowsClient")
     @patch(
@@ -402,9 +400,7 @@ class ConfigureWeniWebChatTestCase(PermissionTestCaseMixin, APIBaseTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.app.refresh_from_db()
-        self.assertEqual(
-            self.app.config["conversationStarters"]["pdp"], False
-        )
+        self.assertEqual(self.app.config["conversationStarters"]["pdp"], False)
 
     @patch("marketplace.core.types.channels.weni_web_chat.serializers.FlowsClient")
     @patch(
@@ -486,6 +482,39 @@ class ConfigureWeniWebChatTestCase(PermissionTestCaseMixin, APIBaseTestCase):
         self.app.refresh_from_db()
         self.assertEqual(self.app.config["profileAvatar"], avatar_url)
         self.assertEqual(self.app.config["openLauncherImage"], launcher_url)
+
+    @patch("marketplace.core.types.channels.weni_web_chat.serializers.FlowsClient")
+    @patch(
+        "marketplace.core.types.channels.weni_web_chat.serializers.AppStorage",
+        MockAppStorage,
+    )
+    def test_configure_preserves_render_percentage_on_update(self, mock_flows_client):
+        self.user_authorization = self.user.authorizations.create(
+            project_uuid=self.app.project_uuid
+        )
+        self.user_authorization.set_role(ProjectAuthorization.ROLE_ADMIN)
+
+        mock_flows_client.return_value.create_channel.return_value = {
+            "uuid": str(uuid.uuid4()),
+        }
+
+        self.body["config"]["renderPercentage"] = 10
+        self.request.patch(self.url, self.body, uuid=self.app.uuid)
+        self.app.refresh_from_db()
+        self.assertEqual(self.app.config["renderPercentage"], 10)
+
+        body_without_render = {
+            "config": {
+                "title": "updated_title",
+                "mainColor": "#009E96",
+                "timeBetweenMessages": 1,
+            }
+        }
+        response = self.request.patch(self.url, body_without_render, uuid=self.app.uuid)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.app.refresh_from_db()
+        self.assertEqual(self.app.config.get("renderPercentage"), 10)
 
     def test_configure_with_invalid_avatar(self):
         self.user_authorization = self.user.authorizations.create(


### PR DESCRIPTION
## What
Merge incoming PATCH data with existing stored config before
serializer processing, so fields not sent in the request retain
their current values instead of being lost.

## Why
The PATCH configure endpoint was replacing the entire config dict,
causing fields like renderPercentage to be silently dropped when
not included in the request payload.