### PR TITLE
fix(wwc): allow clearing profileAvatar, openLauncherImage and customCss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v4.18.1
+----------
+* fix(wwc): allow clearing profileAvatar, openLauncherImage and customCss
+
 v4.18.0
 ----------
 * feat: Add PAYMENT_REQUEST button support for WhatsApp templates

--- a/marketplace/core/types/channels/weni_web_chat/serializers.py
+++ b/marketplace/core/types/channels/weni_web_chat/serializers.py
@@ -49,9 +49,12 @@ class OpenLauncherBase64ImageField(Base64ImageField):
 
 
 class AvatarImageField(serializers.Field):
-    """Accepts either a base64-encoded image or a direct URL."""
+    """Accepts a base64-encoded image, a direct URL, or an empty string to clear it."""
 
     def to_internal_value(self, data):
+        if data == "":
+            return ""
+
         if isinstance(data, str) and data.startswith("data:"):
             base64_field = AvatarBase64ImageField()
             return base64_field.to_internal_value(data)
@@ -68,9 +71,12 @@ class AvatarImageField(serializers.Field):
 
 
 class OpenLauncherImageField(serializers.Field):
-    """Accepts either a base64-encoded image or a direct URL."""
+    """Accepts a base64-encoded image, a direct URL, or an empty string to clear it."""
 
     def to_internal_value(self, data):
+        if data == "":
+            return ""
+
         if isinstance(data, str) and data.startswith("data:"):
             base64_field = OpenLauncherBase64ImageField()
             return base64_field.to_internal_value(data)
@@ -97,7 +103,7 @@ class ConfigSerializer(serializers.Serializer):
     mainColor = serializers.CharField(default="#00DED3")
     profileAvatar = AvatarImageField(required=False)
     openLauncherImage = OpenLauncherImageField(required=False)
-    customCss = serializers.CharField(required=False)
+    customCss = serializers.CharField(required=False, allow_blank=True)
     timeBetweenMessages = serializers.IntegerField(default=1)
     tooltipMessage = serializers.CharField(required=False)
     startFullScreen = serializers.BooleanField(default=False)
@@ -138,6 +144,12 @@ class ConfigSerializer(serializers.Serializer):
 
         data = super().to_internal_value(data)
         storage = AppStorage(self.app)
+
+        # An empty string on these fields means "clear the value" — drop the
+        # key so the stored config no longer keeps the previous URL.
+        for clearable_field in ("profileAvatar", "openLauncherImage", "customCss"):
+            if data.get(clearable_field) == "":
+                data.pop(clearable_field)
 
         if data.get("profileAvatar"):
             avatar = data["profileAvatar"]

--- a/marketplace/core/types/channels/weni_web_chat/tests/test_views.py
+++ b/marketplace/core/types/channels/weni_web_chat/tests/test_views.py
@@ -178,6 +178,10 @@ class AvatarImageFieldTestCase(TestCase):
         self.assertIsInstance(result, ContentFile)
         self.assertEqual(result.name, "avatar.png")
 
+    def test_empty_string_returns_empty_string(self):
+        result = self.field.to_internal_value("")
+        self.assertEqual(result, "")
+
 
 class OpenLauncherImageFieldTestCase(TestCase):
     def setUp(self):
@@ -205,6 +209,10 @@ class OpenLauncherImageFieldTestCase(TestCase):
         result = self.field.to_internal_value(base64_image)
         self.assertIsInstance(result, ContentFile)
         self.assertEqual(result.name, "launcher.png")
+
+    def test_empty_string_returns_empty_string(self):
+        result = self.field.to_internal_value("")
+        self.assertEqual(result, "")
 
 
 class MockAppStorage(MagicMock):
@@ -526,3 +534,114 @@ class ConfigureWeniWebChatTestCase(PermissionTestCaseMixin, APIBaseTestCase):
 
         response = self.request.patch(self.url, self.body, uuid=self.app.uuid)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch("marketplace.core.types.channels.weni_web_chat.serializers.FlowsClient")
+    @patch(
+        "marketplace.core.types.channels.weni_web_chat.serializers.AppStorage",
+        MockAppStorage,
+    )
+    def test_configure_removes_profile_avatar_with_empty_string(
+        self, mock_flows_client
+    ):
+        self.user_authorization = self.user.authorizations.create(
+            project_uuid=self.app.project_uuid
+        )
+        self.user_authorization.set_role(ProjectAuthorization.ROLE_ADMIN)
+
+        mock_flows_client.return_value.create_channel.return_value = {
+            "uuid": str(uuid.uuid4()),
+        }
+
+        avatar_url = "https://example.com/avatar.png"
+        self.body["config"]["profileAvatar"] = avatar_url
+        self.request.patch(self.url, self.body, uuid=self.app.uuid)
+        self.app.refresh_from_db()
+        self.assertEqual(self.app.config["profileAvatar"], avatar_url)
+
+        self.body["config"]["profileAvatar"] = ""
+        response = self.request.patch(self.url, self.body, uuid=self.app.uuid)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.app.refresh_from_db()
+        self.assertNotIn("profileAvatar", self.app.config)
+
+    @patch("marketplace.core.types.channels.weni_web_chat.serializers.FlowsClient")
+    @patch(
+        "marketplace.core.types.channels.weni_web_chat.serializers.AppStorage",
+        MockAppStorage,
+    )
+    def test_configure_removes_open_launcher_image_with_empty_string(
+        self, mock_flows_client
+    ):
+        self.user_authorization = self.user.authorizations.create(
+            project_uuid=self.app.project_uuid
+        )
+        self.user_authorization.set_role(ProjectAuthorization.ROLE_ADMIN)
+
+        mock_flows_client.return_value.create_channel.return_value = {
+            "uuid": str(uuid.uuid4()),
+        }
+
+        launcher_url = "https://example.com/launcher.png"
+        self.body["config"]["openLauncherImage"] = launcher_url
+        self.request.patch(self.url, self.body, uuid=self.app.uuid)
+        self.app.refresh_from_db()
+        self.assertEqual(self.app.config["openLauncherImage"], launcher_url)
+
+        self.body["config"]["openLauncherImage"] = ""
+        response = self.request.patch(self.url, self.body, uuid=self.app.uuid)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.app.refresh_from_db()
+        self.assertNotIn("openLauncherImage", self.app.config)
+
+    @patch("marketplace.core.types.channels.weni_web_chat.serializers.FlowsClient")
+    @patch(
+        "marketplace.core.types.channels.weni_web_chat.serializers.AppStorage",
+        MockAppStorage,
+    )
+    def test_configure_removes_custom_css_with_empty_string(self, mock_flows_client):
+        self.user_authorization = self.user.authorizations.create(
+            project_uuid=self.app.project_uuid
+        )
+        self.user_authorization.set_role(ProjectAuthorization.ROLE_ADMIN)
+
+        mock_flows_client.return_value.create_channel.return_value = {
+            "uuid": str(uuid.uuid4()),
+        }
+
+        self.body["config"]["customCss"] = "body { background-color: red; }"
+        self.request.patch(self.url, self.body, uuid=self.app.uuid)
+        self.app.refresh_from_db()
+        self.assertIn("customCss", self.app.config)
+
+        self.body["config"]["customCss"] = ""
+        response = self.request.patch(self.url, self.body, uuid=self.app.uuid)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.app.refresh_from_db()
+        self.assertNotIn("customCss", self.app.config)
+
+    @patch("marketplace.core.types.channels.weni_web_chat.serializers.FlowsClient")
+    @patch(
+        "marketplace.core.types.channels.weni_web_chat.serializers.AppStorage",
+        MockAppStorage,
+    )
+    def test_configure_empty_avatar_on_app_without_avatar_is_noop(
+        self, mock_flows_client
+    ):
+        self.user_authorization = self.user.authorizations.create(
+            project_uuid=self.app.project_uuid
+        )
+        self.user_authorization.set_role(ProjectAuthorization.ROLE_ADMIN)
+
+        mock_flows_client.return_value.create_channel.return_value = {
+            "uuid": str(uuid.uuid4()),
+        }
+
+        self.body["config"]["profileAvatar"] = ""
+        response = self.request.patch(self.url, self.body, uuid=self.app.uuid)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.app.refresh_from_db()
+        self.assertNotIn("profileAvatar", self.app.config)

--- a/marketplace/swagger.py
+++ b/marketplace/swagger.py
@@ -6,7 +6,7 @@ from rest_framework import permissions
 view = get_schema_view(
     openapi.Info(
         title="Integrations API Documentation",
-        default_version="v4.18.0",
+        default_version="v4.18.1",
         desccription="Documentation of the Integrations APIs",
     ),
     public=True,


### PR DESCRIPTION
### What

Let the Weni Web Chat `ConfigSerializer` accept an empty string (`""`) on `profileAvatar`, `openLauncherImage`, and `customCss` as an explicit "clear" signal. When the incoming payload carries `""` for any of these fields, the key is dropped from the data returned by `to_internal_value`, so the saved `App.config` no longer contains the previous URL and the generated widget script stops referencing it. `customCss` additionally gains `allow_blank=True`, and `AvatarImageField` / `OpenLauncherImageField` short-circuit on `""` before their URL/base64 validation. Added 5 new tests (`test_empty_string_returns_empty_string` for both image fields, plus three configure-flow tests verifying the key is removed from `app.config` when cleared and that sending `""` on an app that never had an avatar is a no-op).

### Why

The frontend was unable to actually remove a saved `profileAvatar` (or `openLauncherImage` / `customCss`): sending `null` got stripped on the client side by `removeEmpty`, and the serializer's `_merge_with_existing_config` would re-inject the existing URL whenever the field was absent from the payload. Sending `""` or `null` directly was rejected by `AvatarImageField` (URL validation) and by the default `CharField` blank check on `customCss`, so there was no way to clear the value once stored. This change gives the frontend a safe, explicit removal signal while keeping URL/base64 validation intact for every other case. Paired with the frontend fix in weni-integrations-webapp that sends `""` when the user deletes the file.

Made with [Cursor](https://cursor.com)