### PR TITLE
fix(wwc): allow clearing subtitle, initPayload, tooltipMessage and inputTextFieldHint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v4.18.2
+----------
+* fix(wwc): allow clearing subtitle, initPayload, tooltipMessage and inputTextFieldHint
+
 v4.18.1
 ----------
 * fix(wwc): allow clearing profileAvatar, openLauncherImage and customCss

--- a/marketplace/core/types/channels/weni_web_chat/serializers.py
+++ b/marketplace/core/types/channels/weni_web_chat/serializers.py
@@ -94,18 +94,20 @@ class OpenLauncherImageField(serializers.Field):
 
 class ConfigSerializer(serializers.Serializer):
     title = serializers.CharField(required=True)
-    subtitle = serializers.CharField(required=False)
-    inputTextFieldHint = serializers.CharField(default="Type a message...")
+    subtitle = serializers.CharField(required=False, allow_blank=True)
+    inputTextFieldHint = serializers.CharField(
+        default="Type a message...", allow_blank=True
+    )
     showFullScreenButton = serializers.BooleanField(default=True)
     displayUnreadCount = serializers.BooleanField(default=False)
     keepHistory = serializers.BooleanField(default=False)
-    initPayload = serializers.CharField(required=False)
+    initPayload = serializers.CharField(required=False, allow_blank=True)
     mainColor = serializers.CharField(default="#00DED3")
     profileAvatar = AvatarImageField(required=False)
     openLauncherImage = OpenLauncherImageField(required=False)
     customCss = serializers.CharField(required=False, allow_blank=True)
     timeBetweenMessages = serializers.IntegerField(default=1)
-    tooltipMessage = serializers.CharField(required=False)
+    tooltipMessage = serializers.CharField(required=False, allow_blank=True)
     startFullScreen = serializers.BooleanField(default=False)
     showVoiceRecordingButton = serializers.BooleanField(default=False)
     showCameraButton = serializers.BooleanField(default=False)

--- a/marketplace/core/types/channels/weni_web_chat/tests/test_views.py
+++ b/marketplace/core/types/channels/weni_web_chat/tests/test_views.py
@@ -645,3 +645,41 @@ class ConfigureWeniWebChatTestCase(PermissionTestCaseMixin, APIBaseTestCase):
 
         self.app.refresh_from_db()
         self.assertNotIn("profileAvatar", self.app.config)
+
+    @patch("marketplace.core.types.channels.weni_web_chat.serializers.FlowsClient")
+    @patch(
+        "marketplace.core.types.channels.weni_web_chat.serializers.AppStorage",
+        MockAppStorage,
+    )
+    def test_configure_clears_text_fields_with_empty_string(self, mock_flows_client):
+        self.user_authorization = self.user.authorizations.create(
+            project_uuid=self.app.project_uuid
+        )
+        self.user_authorization.set_role(ProjectAuthorization.ROLE_ADMIN)
+
+        mock_flows_client.return_value.create_channel.return_value = {
+            "uuid": str(uuid.uuid4()),
+        }
+
+        clearable_fields = {
+            "subtitle": "Any subtitle",
+            "initPayload": "start",
+            "tooltipMessage": "Need help?",
+            "inputTextFieldHint": "Type here...",
+        }
+
+        for field_name, field_value in clearable_fields.items():
+            with self.subTest(field=field_name):
+                self.body["config"][field_name] = field_value
+                self.request.patch(self.url, self.body, uuid=self.app.uuid)
+                self.app.refresh_from_db()
+                self.assertEqual(self.app.config.get(field_name), field_value)
+
+                self.body["config"][field_name] = ""
+                response = self.request.patch(
+                    self.url, self.body, uuid=self.app.uuid
+                )
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                self.app.refresh_from_db()
+                self.assertEqual(self.app.config.get(field_name), "")

--- a/marketplace/swagger.py
+++ b/marketplace/swagger.py
@@ -6,7 +6,7 @@ from rest_framework import permissions
 view = get_schema_view(
     openapi.Info(
         title="Integrations API Documentation",
-        default_version="v4.18.1",
+        default_version="v4.18.2",
         desccription="Documentation of the Integrations APIs",
     ),
     public=True,


### PR DESCRIPTION
### What

Add `allow_blank=True` to `subtitle`, `inputTextFieldHint`, `initPayload`, and `tooltipMessage` on the Weni Web Chat `ConfigSerializer`. With this, sending `""` for any of these fields is accepted as an explicit "clear this field" signal. The existing `_merge_with_existing_config` already writes the empty value through whenever the key is present in the incoming payload, so no merge logic change is needed — the stored `App.config` now contains `"subtitle": ""` (and the generated widget script mirrors that) instead of re-injecting the previous value. Added a parameterized regression test (`test_configure_clears_text_fields_with_empty_string`) that configures each of the four fields with a value, then PATCHes `""` and asserts the stored config reflects the cleared state.

### Why

The frontend had no way to actually clear a previously saved `subtitle` / `initPayload` / `tooltipMessage` / `inputTextFieldHint`: sending `null` got stripped on the client side by `removeEmpty`, and the serializer's `_merge_with_existing_config` would re-inject the existing value whenever the field was absent from the payload. Sending `""` directly was rejected by the default `CharField` blank check, so there was no way to remove the value once stored. This change gives the frontend the same explicit removal signal that already works for `profileAvatar`, `openLauncherImage`, and `customCss` (#793), extending that working pattern to the remaining appearance-tab text fields. Paired with the frontend fix in weni-integrations-webapp that sends `""` instead of `null` when the user clears these inputs.

Made with [Cursor](https://cursor.com)