### PR TITLE
feat: auto-delete successful uploads and track totals via CatalogUploadCounter

### DIFF
--- a/marketplace/wpp_products/migrations/0015_catalogupload_counter.py
+++ b/marketplace/wpp_products/migrations/0015_catalogupload_counter.py
@@ -1,0 +1,57 @@
+import django.db.models.deletion
+
+from django.db import migrations, models
+
+
+def populate_counters(apps, schema_editor):
+    """Create a zeroed counter for every existing Catalog."""
+    Catalog = apps.get_model("wpp_products", "Catalog")
+    CatalogUploadCounter = apps.get_model("wpp_products", "CatalogUploadCounter")
+
+    catalog_ids = Catalog.objects.values_list("id", flat=True)
+    CatalogUploadCounter.objects.bulk_create(
+        [CatalogUploadCounter(catalog_id=catalog_id) for catalog_id in catalog_ids],
+        ignore_conflicts=True,
+        batch_size=1000,
+    )
+
+
+def noop_reverse(apps, schema_editor):
+    """No-op reverse: dropping the table already removes the data."""
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("wpp_products", "0014_auto_20250912_1456"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="CatalogUploadCounter",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("total_success", models.BigIntegerField(default=0)),
+                ("total_error", models.BigIntegerField(default=0)),
+                ("last_success_at", models.DateTimeField(blank=True, null=True)),
+                ("last_error_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "catalog",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="upload_counter",
+                        to="wpp_products.catalog",
+                    ),
+                ),
+            ],
+        ),
+        migrations.RunPython(populate_counters, noop_reverse),
+    ]

--- a/marketplace/wpp_products/migrations/0015_catalogupload_counter.py
+++ b/marketplace/wpp_products/migrations/0015_catalogupload_counter.py
@@ -3,24 +3,6 @@ import django.db.models.deletion
 from django.db import migrations, models
 
 
-def populate_counters(apps, schema_editor):
-    """Create a zeroed counter for every existing Catalog."""
-    Catalog = apps.get_model("wpp_products", "Catalog")
-    CatalogUploadCounter = apps.get_model("wpp_products", "CatalogUploadCounter")
-
-    catalog_ids = Catalog.objects.values_list("id", flat=True)
-    CatalogUploadCounter.objects.bulk_create(
-        [CatalogUploadCounter(catalog_id=catalog_id) for catalog_id in catalog_ids],
-        ignore_conflicts=True,
-        batch_size=1000,
-    )
-
-
-def noop_reverse(apps, schema_editor):
-    """No-op reverse: dropping the table already removes the data."""
-    pass
-
-
 class Migration(migrations.Migration):
     dependencies = [
         ("wpp_products", "0014_auto_20250912_1456"),
@@ -53,5 +35,4 @@ class Migration(migrations.Migration):
                 ),
             ],
         ),
-        migrations.RunPython(populate_counters, noop_reverse),
     ]

--- a/marketplace/wpp_products/models.py
+++ b/marketplace/wpp_products/models.py
@@ -229,6 +229,32 @@ class UploadProduct(models.Model):
         return cls.objects.filter(id__in=list(ids))
 
 
+class CatalogUploadCounter(models.Model):
+    """
+    Aggregated counters of upload outcomes per catalog.
+
+    Used to track upload progress without keeping per-product success rows
+    in `UploadProduct`. Successful uploads are deleted right after Meta
+    confirms them and the totals are bumped here via atomic `F()` updates.
+    """
+
+    catalog = models.OneToOneField(
+        Catalog,
+        on_delete=models.CASCADE,
+        related_name="upload_counter",
+    )
+    total_success = models.BigIntegerField(default=0)
+    total_error = models.BigIntegerField(default=0)
+    last_success_at = models.DateTimeField(null=True, blank=True)
+    last_error_at = models.DateTimeField(null=True, blank=True)
+
+    def __str__(self):
+        return (
+            f"{self.catalog.name} "
+            f"(success={self.total_success}, error={self.total_error})"
+        )
+
+
 class WebhookLog(models.Model):
     sku_id = models.IntegerField()
     data = JSONField()

--- a/marketplace/wpp_products/tests/test_utils_extra.py
+++ b/marketplace/wpp_products/tests/test_utils_extra.py
@@ -24,25 +24,67 @@ class TestExtractSkuId(SimpleTestCase):
 
 
 class TestProductUploadManager(SimpleTestCase):
+    @patch("marketplace.wpp_products.utils.CatalogUploadCounter")
     @patch("marketplace.wpp_products.utils.UploadProduct")
-    def test_mark_products_as_sent(self, mock_upload):
-        mock_upload.objects.filter.return_value.update.return_value = 3
-        mgr = ProductUploadManager()
-        mgr.mark_products_as_sent(["1", "2"])
-        mock_upload.objects.filter.assert_called_once()
-        mock_upload.objects.filter.return_value.update.assert_called_once_with(
-            status="success"
-        )
+    def test_mark_products_as_sent_deletes_and_bumps_counter(
+        self, mock_upload, mock_counter
+    ):
+        mock_upload.objects.filter.return_value.delete.return_value = (3, {})
+        catalog = MagicMock(name="Catalog")
 
-    @patch("marketplace.wpp_products.utils.UploadProduct")
-    def test_mark_products_as_error(self, mock_upload):
-        mock_upload.objects.filter.return_value.update.return_value = 2
         mgr = ProductUploadManager()
-        mgr.mark_products_as_error(["1", "2"])
-        mock_upload.objects.filter.assert_called_once()
+        result = mgr.mark_products_as_sent(catalog, ["1", "2"])
+
+        self.assertEqual(result, 3)
+        mock_upload.objects.filter.assert_called_once_with(
+            facebook_product_id__in=["1", "2"],
+            catalog=catalog,
+            status="processing",
+        )
+        mock_upload.objects.filter.return_value.delete.assert_called_once()
+        mock_counter.objects.get_or_create.assert_called_once_with(catalog=catalog)
+        mock_counter.objects.filter.assert_called_once_with(catalog=catalog)
+        mock_counter.objects.filter.return_value.update.assert_called_once()
+
+    @patch("marketplace.wpp_products.utils.CatalogUploadCounter")
+    @patch("marketplace.wpp_products.utils.UploadProduct")
+    def test_mark_products_as_sent_no_rows_skips_counter(
+        self, mock_upload, mock_counter
+    ):
+        mock_upload.objects.filter.return_value.delete.return_value = (0, {})
+        mgr = ProductUploadManager()
+        result = mgr.mark_products_as_sent(MagicMock(), ["1"])
+        self.assertEqual(result, 0)
+        mock_counter.objects.filter.assert_not_called()
+
+    @patch("marketplace.wpp_products.utils.CatalogUploadCounter")
+    @patch("marketplace.wpp_products.utils.UploadProduct")
+    def test_mark_products_as_error_updates_and_bumps_counter(
+        self, mock_upload, mock_counter
+    ):
+        mock_upload.objects.filter.return_value.update.return_value = 2
+        catalog = MagicMock(name="Catalog")
+
+        mgr = ProductUploadManager()
+        result = mgr.mark_products_as_error(catalog, ["1", "2"])
+
+        self.assertEqual(result, 2)
         mock_upload.objects.filter.return_value.update.assert_called_once_with(
             status="error"
         )
+        mock_counter.objects.get_or_create.assert_called_once_with(catalog=catalog)
+        mock_counter.objects.filter.assert_called_once_with(catalog=catalog)
+
+    @patch("marketplace.wpp_products.utils.CatalogUploadCounter")
+    @patch("marketplace.wpp_products.utils.UploadProduct")
+    def test_mark_products_as_error_no_rows_skips_counter(
+        self, mock_upload, mock_counter
+    ):
+        mock_upload.objects.filter.return_value.update.return_value = 0
+        mgr = ProductUploadManager()
+        result = mgr.mark_products_as_error(MagicMock(), ["1"])
+        self.assertEqual(result, 0)
+        mock_counter.objects.filter.assert_not_called()
 
 
 class QuerySetFake:
@@ -348,24 +390,18 @@ class TestProductBatchUploader(SimpleTestCase):
 
         uploader.product_manager = DummyPM()
         redis = MagicMock()
-        uploader.log_sent_products = MagicMock()
 
         uploader.process_and_upload(
             redis_client=redis, lock_key="lk", lock_expiration_time=60
         )
 
-        uploader.product_manager.mark_products_as_sent.assert_called_once_with(["11#x"])
+        uploader.product_manager.mark_products_as_sent.assert_called_once_with(
+            uploader.catalog, ["11#x"]
+        )
         uploader.product_manager.mark_products_as_error.assert_called_once_with(
-            ["22#y"]
+            uploader.catalog, ["22#y"]
         )
         self.assertEqual(redis.expire.call_count, 2)
-        uploader.log_sent_products.assert_called_once()
-
-    @patch("marketplace.wpp_products.utils.ProductUploadLog")
-    def test_log_sent_products(self, mock_log):
-        uploader = ProductBatchUploader(self._make_catalog())
-        uploader.log_sent_products(["11#x", "22#y"])
-        self.assertEqual(mock_log.objects.create.call_count, 2)
 
 
 class TestRedisQueue(SimpleTestCase):

--- a/marketplace/wpp_products/utils.py
+++ b/marketplace/wpp_products/utils.py
@@ -4,13 +4,14 @@ import time
 
 from typing import List, Dict, Any
 
-from datetime import datetime, timezone
+from datetime import datetime, timezone as dt_timezone
 
 from django.conf import settings
+from django.utils import timezone
 
 from marketplace.services.vtex.utils.enums import ProductPriority
 
-from django.db.models import QuerySet
+from django.db.models import F, QuerySet
 
 from django_redis import get_redis_connection
 
@@ -21,7 +22,7 @@ from marketplace.clients.rapidpro.client import RapidproClient
 from marketplace.services.rapidpro.service import RapidproService
 from marketplace.wpp_products.models import (
     Catalog,
-    ProductUploadLog,
+    CatalogUploadCounter,
     ProductValidation,
     UploadProduct,
 )
@@ -35,19 +36,81 @@ logger = logging.getLogger(__name__)
 
 
 class ProductUploadManager:
-    def mark_products_as_sent(self, product_ids: List[str]):
-        updated_count = UploadProduct.objects.filter(
-            facebook_product_id__in=product_ids, status="processing"
-        ).update(status="success")
+    def mark_products_as_sent(self, catalog: Catalog, product_ids: List[str]) -> int:
+        """
+        Delete successfully uploaded products and bump the catalog counter.
 
-        print(f"{updated_count} products successfully marked as sent.")
+        Successful uploads are not kept in `UploadProduct` since nothing
+        consumes them after Meta confirms; persisting them only inflates
+        the table. The aggregated count is preserved in
+        `CatalogUploadCounter` for observability.
+        """
+        deleted_count, _ = UploadProduct.objects.filter(
+            facebook_product_id__in=product_ids,
+            catalog=catalog,
+            status="processing",
+        ).delete()
 
-    def mark_products_as_error(self, product_ids: List[str]):
+        if deleted_count:
+            self._bump_counter(
+                catalog=catalog,
+                success_delta=deleted_count,
+                last_success_at=timezone.now(),
+            )
+
+        logger.info(
+            f"{deleted_count} products successfully marked as sent "
+            f"for catalog {catalog.name}."
+        )
+        return deleted_count
+
+    def mark_products_as_error(self, catalog: Catalog, product_ids: List[str]) -> int:
+        """
+        Mark products as `error` so the cleanup task can recycle them to
+        `pending` later, and bump the catalog error counter.
+        """
         updated_count = UploadProduct.objects.filter(
-            facebook_product_id__in=product_ids, status="processing"
+            facebook_product_id__in=product_ids,
+            catalog=catalog,
+            status="processing",
         ).update(status="error")
 
-        print(f"{updated_count} products marked as error.")
+        if updated_count:
+            self._bump_counter(
+                catalog=catalog,
+                error_delta=updated_count,
+                last_error_at=timezone.now(),
+            )
+
+        logger.info(
+            f"{updated_count} products marked as error " f"for catalog {catalog.name}."
+        )
+        return updated_count
+
+    @staticmethod
+    def _bump_counter(
+        catalog: Catalog,
+        success_delta: int = 0,
+        error_delta: int = 0,
+        last_success_at=None,
+        last_error_at=None,
+    ) -> None:
+        """Atomically bump the catalog upload counter via `F()` expressions."""
+        updates = {}
+        if success_delta:
+            updates["total_success"] = F("total_success") + success_delta
+        if error_delta:
+            updates["total_error"] = F("total_error") + error_delta
+        if last_success_at is not None:
+            updates["last_success_at"] = last_success_at
+        if last_error_at is not None:
+            updates["last_error_at"] = last_error_at
+
+        if not updates:
+            return
+
+        CatalogUploadCounter.objects.get_or_create(catalog=catalog)
+        CatalogUploadCounter.objects.filter(catalog=catalog).update(**updates)
 
 
 class ProductBatchFetcher(ProductUploadManager):
@@ -90,7 +153,7 @@ class SellerSyncUtils:
             {
                 "app_uuid": app_uuid,
                 "sellers": sellers,
-                "start_time": datetime.now(timezone.utc).isoformat(),
+                "start_time": datetime.now(dt_timezone.utc).isoformat(),
             }
         )
 
@@ -303,10 +366,13 @@ class ProductBatchUploader:
                 payload = self.create_batch_payload(products)
                 # Sends data to Meta and processes the results
                 if self.send_to_meta(payload):
-                    self.product_manager.mark_products_as_sent(product_ids)
-                    self.log_sent_products(product_ids)
+                    self.product_manager.mark_products_as_sent(
+                        self.catalog, product_ids
+                    )
                 else:
-                    self.product_manager.mark_products_as_error(product_ids)
+                    self.product_manager.mark_products_as_error(
+                        self.catalog, product_ids
+                    )
 
                 # Apply delay based on priority
                 # If priority is DEFAULT, apply delay from settings
@@ -326,7 +392,7 @@ class ProductBatchUploader:
                 exc_info=True,
                 stack_info=True,
             )
-            self.product_manager.mark_products_as_error(product_ids)
+            self.product_manager.mark_products_as_error(self.catalog, product_ids)
             try:
                 # Send notification error to Rapidpro
                 self.rapidpro_service.create_notification(
@@ -379,17 +445,6 @@ class ProductBatchUploader:
                 stack_info=True,
             )
             return False
-
-    def log_sent_products(self, product_ids: List[str]):
-        """
-        Logs the successfully sent products to the log table.
-        """
-        for product_id in product_ids:
-            sku_id = extract_sku_id(product_id)
-            ProductUploadLog.objects.create(
-                sku_id=sku_id, vtex_app=self.catalog.vtex_app
-            )
-        print(f"Logged {len(product_ids)} products as sent.")
 
 
 class RedisQueue:


### PR DESCRIPTION
## What

- New `CatalogUploadCounter` model (1:1 with `Catalog`) to aggregate `total_success`, `total_error`, `last_success_at`, `last_error_at`.
- `mark_products_as_sent` now deletes `UploadProduct` rows on success and bumps the counter atomically (`F()` expressions). Counter row is created lazily via `get_or_create` on the first batch of each catalog.
- `mark_products_as_error` keeps marking rows as `error` (so the cleanup task can recycle them to `pending`) and bumps `total_error` / `last_error_at`.
- Removed the per-SKU `ProductUploadLog` insert loop from `process_and_upload`.
- Migration `0015_catalogupload_counter` creates the table.
- `print` replaced with `logger.info` in the refactored methods.

## Why

While analyzing a recent client incident, we observed a large volume of `success` rows in `UploadProduct` (and the equivalent per-SKU rows in `ProductUploadLog`) accumulating throughout the day. Nothing in the codebase reads those rows after Meta confirms the upload — they only sit in the database until the nightly cleanup task removes them, contributing to disk pressure during peak hours.

Deleting on success and tracking aggregates in a dedicated counter:

- Keeps `UploadProduct` lean (only `pending`, `processing`, `error` matter).
- Eliminates 5000 INSERTs per successful batch in `ProductUploadLog`.
- Makes upload progress observable via `catalog.upload_counter` without hitting Meta.
- Removes pressure from the midnight cleanup task.