### PR TITLE
chore: Rename WWC display name from Web Chat to Shopping Assistant

### DIFF
--- a/marketplace/core/types/channels/weni_web_chat/type.py
+++ b/marketplace/core/types/channels/weni_web_chat/type.py
@@ -7,7 +7,7 @@ class WeniWebChatType(AppType):
     view_class = views.WeniWebChatViewSet
     code = "wwc"
     flows_type_code = "WWC"
-    name = "Web Chat"
+    name = "Shopping Assistant"
     description = "weniWebChat.data.description"
     summary = "weniWebChat.data.summary"
     category = AppType.CATEGORY_CHANNEL

--- a/marketplace/core/types/tests/test__init__.py
+++ b/marketplace/core/types/tests/test__init__.py
@@ -15,7 +15,7 @@ class FakeType:
 class AppTypesDictTestCase(TestCase):
     def setUp(self):
         self.apptypes = AppTypesDict()
-        self.apptypes["wwc"] = FakeType("wwc", "channel", "Weni Web Chat")
+        self.apptypes["wwc"] = FakeType("wwc", "channel", "Shopping Assistant")
         self.apptypes["tg"] = FakeType("tg", "channel", "Telegram")
         self.apptypes["rc"] = FakeType("rc", "chat", "Rocket Chat")
 


### PR DESCRIPTION
## What
Renames the WWC AppType display name from "Web Chat" to "Shopping Assistant".
Internal identifiers (`code = "wwc"`, `flows_type_code`, classes, package path, i18n keys and HTTP contracts) are preserved.

## Why
Product rebranding of the WWC channel in the marketplace.