### PR TITLE
feat(whatsapp): add sync task for mmlite status and implement use case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v4.19.0
+----------
+* feat(whatsapp): add sync task for mmlite status and implement use case
+
 v4.18.3
 ----------
 * feat(wwc): support v3 webchat and apply connectOn rule for v2+

--- a/marketplace/core/types/channels/whatsapp_cloud/tasks.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/tasks.py
@@ -4,7 +4,12 @@ from marketplace.celery import app as celery_app
 from marketplace.clients.flows.client import FlowsClient
 from marketplace.applications.models import App
 from marketplace.accounts.models import ProjectAuthorization
-from marketplace.core.types.channels.whatsapp_cloud.factories import create_account_update_webhook_event_processor
+from marketplace.core.types.channels.whatsapp_cloud.factories import (
+    create_account_update_webhook_event_processor,
+)
+from marketplace.core.types.channels.whatsapp_cloud.usecases.mmlite_status_sync import (
+    SyncMmliteStatusUseCase,
+)
 from marketplace.core.types.channels.whatsapp_cloud.usecases.whatsapp_cloud_sync import (
     SyncWhatsAppCloudAppsUseCase,
 )
@@ -18,6 +23,13 @@ User = get_user_model()
 def sync_whatsapp_cloud_apps():
     """Synchronize WhatsApp Cloud apps with Flows channels."""
     use_case = SyncWhatsAppCloudAppsUseCase()
+    return use_case.execute()
+
+
+@celery_app.task(name="sync_whatsapp_cloud_mmlite_status")
+def sync_whatsapp_cloud_mmlite_status():
+    """Reconcile mmlite_status for wpp-cloud apps against Meta, deduped by WABA."""
+    use_case = SyncMmliteStatusUseCase()
     return use_case.execute()
 
 
@@ -83,7 +95,9 @@ def update_account_info_by_webhook(**kwargs):  # pragma: no cover
 
             whatsapp_business_account_id = value.get("waba_info", {}).get("waba_id")
             if not whatsapp_business_account_id:
-                logger.info(f"Whatsapp business account id not found in webhook data: {webhook_data}")
+                logger.info(
+                    f"Whatsapp business account id not found in webhook data: {webhook_data}"
+                )
                 continue
 
             if field in allowed_event_types:

--- a/marketplace/core/types/channels/whatsapp_cloud/tests/test_tasks.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/tests/test_tasks.py
@@ -10,6 +10,7 @@ from django.contrib.auth import get_user_model
 from marketplace.core.types import APPTYPES
 from ..tasks import (
     sync_whatsapp_cloud_apps,
+    sync_whatsapp_cloud_mmlite_status,
     check_apps_uncreated_on_flow,
     update_account_info_by_webhook,
 )
@@ -610,3 +611,19 @@ class UpdateAccountInfoByWebhookTaskTestCase(TestCase):
         )
         mock_logger.info.assert_any_call("-" * 50)
         self.mock_processor.process_event.assert_not_called()
+
+
+class SyncWhatsAppCloudMmliteStatusTaskTestCase(TestCase):
+    @patch(
+        "marketplace.core.types.channels.whatsapp_cloud.tasks.SyncMmliteStatusUseCase"
+    )
+    def test_task_delegates_to_use_case(self, mock_use_case_cls):
+        mock_use_case = MagicMock()
+        mock_use_case.execute.return_value = {"candidates": 0}
+        mock_use_case_cls.return_value = mock_use_case
+
+        result = sync_whatsapp_cloud_mmlite_status()
+
+        mock_use_case_cls.assert_called_once_with()
+        mock_use_case.execute.assert_called_once_with()
+        self.assertEqual(result, {"candidates": 0})

--- a/marketplace/core/types/channels/whatsapp_cloud/tests/test_views.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/tests/test_views.py
@@ -461,6 +461,16 @@ class CreateWhatsAppCloudTestCase(APIBaseTestCase):
             "status": "success"
         }
 
+        self.mock_mmlite_sync = Mock()
+        self.mock_mmlite_sync.sync_for_app.return_value = {
+            "candidates": 0,
+            "wabas": 0,
+            "propagated": 0,
+            "activated_via_meta": 0,
+            "skipped_not_onboarded": 0,
+            "errors": 0,
+        }
+
         # Mock services
         self.mock_business_meta_service = MockBusinessMetaService()
         self.mock_phone_numbers_service = MockPhoneNumbersService()
@@ -481,6 +491,11 @@ class CreateWhatsAppCloudTestCase(APIBaseTestCase):
             new=Mock(return_value=self.mock_insights_sync),
         )
 
+        patcher_mmlite_sync = patch(
+            "marketplace.core.types.channels.whatsapp_cloud.views.SyncMmliteStatusUseCase",
+            new=Mock(return_value=self.mock_mmlite_sync),
+        )
+
         patcher_biz_meta = patch(
             "marketplace.core.types.channels.whatsapp_cloud.views.BusinessMetaService",
             new=Mock(return_value=self.mock_business_meta_service),
@@ -498,6 +513,7 @@ class CreateWhatsAppCloudTestCase(APIBaseTestCase):
         patcher_waba_sync.start()
         patcher_phone_sync.start()
         patcher_insights_sync.start()
+        patcher_mmlite_sync.start()
         patcher_biz_meta.start()
         patcher_phone.start()
         patcher_flows.start()
@@ -506,6 +522,7 @@ class CreateWhatsAppCloudTestCase(APIBaseTestCase):
         self.addCleanup(patcher_waba_sync.stop)
         self.addCleanup(patcher_phone_sync.stop)
         self.addCleanup(patcher_insights_sync.stop)
+        self.addCleanup(patcher_mmlite_sync.stop)
         self.addCleanup(patcher_biz_meta.stop)
         self.addCleanup(patcher_phone.stop)
         self.addCleanup(patcher_flows.stop)
@@ -563,6 +580,15 @@ class CreateWhatsAppCloudTestCase(APIBaseTestCase):
         response = self.request.post(self.url, body=self.payload)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json, ["Registration failed"])
+
+    def test_create_whatsapp_cloud_calls_mmlite_sync_for_new_app(self):
+        response = self.request.post(self.url, body=self.payload)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        app = App.objects.get(project_uuid=self.payload["project_uuid"])
+        self.mock_mmlite_sync.sync_for_app.assert_called_once()
+        called_app = self.mock_mmlite_sync.sync_for_app.call_args.args[0]
+        self.assertEqual(called_app.uuid, app.uuid)
 
 
 class MockCloudProfileContactFacade:
@@ -706,16 +732,20 @@ class UpdateMmliteStatusTestCase(APIBaseTestCase):
             "config": {"existing_flow_key": "existing_flow_value"}
         }
 
+        usecase_module = (
+            "marketplace.core.types.channels.whatsapp_cloud."
+            "usecases.mmlite_status_sync"
+        )
         patcher_facebook = patch(
-            "marketplace.core.types.channels.whatsapp_cloud.views.FacebookClient",
+            f"{usecase_module}.FacebookClient",
             return_value=self.mock_facebook_client,
         )
         patcher_business_service = patch(
-            "marketplace.core.types.channels.whatsapp_cloud.views.BusinessMetaService",
+            f"{usecase_module}.BusinessMetaService",
             return_value=self.mock_business_service,
         )
         patcher_flows_client = patch(
-            "marketplace.core.types.channels.whatsapp_cloud.views.FlowsClient",
+            f"{usecase_module}.FlowsClient",
             return_value=self.mock_flows_client,
         )
 
@@ -891,6 +921,24 @@ class UpdateMmliteStatusTestCase(APIBaseTestCase):
         self.request.patch(self.url, data, uuid=self.app.uuid)
 
         self.mock_flows_client.detail_channel.assert_not_called()
+        self.mock_flows_client.update_config.assert_not_called()
+
+    def test_update_mmlite_status_falls_back_to_user_status_when_meta_errors(self):
+        self.mock_business_service.get_mmlite_status.side_effect = Exception(
+            "meta down"
+        )
+
+        with patch(
+            "marketplace.core.types.channels.whatsapp_cloud."
+            "usecases.mmlite_status_sync.sentry_sdk.capture_exception"
+        ):
+            response = self.request.patch(
+                self.url, {"status": "in_progress"}, uuid=self.app.uuid
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        app = App.objects.get(uuid=self.app.uuid)
+        self.assertEqual(app.config["mmlite_status"], "in_progress")
         self.mock_flows_client.update_config.assert_not_called()
 
     def test_update_mmlite_status_nonexistent_app(self):

--- a/marketplace/core/types/channels/whatsapp_cloud/usecases/mmlite_status_sync.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/usecases/mmlite_status_sync.py
@@ -1,0 +1,170 @@
+import logging
+from collections import defaultdict
+from typing import Callable, Dict, List, Optional
+
+import sentry_sdk
+from django_redis import get_redis_connection
+
+from marketplace.applications.models import App
+from marketplace.clients.facebook.client import FacebookClient
+from marketplace.clients.flows.client import FlowsClient
+from marketplace.services.facebook.service import BusinessMetaService
+
+
+logger = logging.getLogger(__name__)
+
+
+SYNC_WHATSAPP_CLOUD_MMLITE_STATUS_LOCK_KEY = "sync-whatsapp-cloud-mmlite-status-lock"
+WPP_CLOUD_CODE = "wpp-cloud"
+MMLITE_STATUS_ACTIVE = "active"
+META_ONBOARDING_STATUS_ONBOARDED = "ONBOARDED"
+
+
+class SyncMmliteStatusUseCase:
+    """Reconcile mmlite_status for wpp-cloud apps against Meta.
+
+    Apps are grouped by `wa_waba_id` so each WABA is queried at most once. When
+    any app sharing the WABA is already `active`, the remaining apps are flipped
+    locally without a Meta call (sibling propagation). Whenever an app is flipped
+    to `active`, the Flows channel config is also updated with `mmlite: True`.
+    """
+
+    def __init__(
+        self,
+        business_service_factory: Optional[Callable[[App], BusinessMetaService]] = None,
+        flows_client: Optional[FlowsClient] = None,
+        redis_connection=None,
+    ):
+        self._business_service_factory = (
+            business_service_factory or self._default_business_service_factory
+        )
+        self.flows_client = flows_client or FlowsClient()
+        self.redis = redis_connection or get_redis_connection()
+
+    def execute(self) -> Optional[Dict[str, int]]:
+        if self._is_locked():
+            logger.info(
+                "MMLite status sync is already running by another task, skipping."
+            )
+            return None
+
+        summary = {
+            "candidates": 0,
+            "wabas": 0,
+            "propagated": 0,
+            "activated_via_meta": 0,
+            "skipped_not_onboarded": 0,
+            "errors": 0,
+        }
+
+        try:
+            self._acquire_lock()
+            grouped = self._group_candidates_by_waba()
+            summary["wabas"] = len(grouped)
+            summary["candidates"] = sum(len(apps) for apps in grouped.values())
+
+            for waba_id, apps in grouped.items():
+                try:
+                    self._process_waba_group(waba_id, apps, summary)
+                except Exception as exc:
+                    summary["errors"] += 1
+                    logger.error(
+                        f"Error syncing mmlite status for waba {waba_id}: {exc}"
+                    )
+                    sentry_sdk.capture_exception(exc)
+
+            return summary
+        finally:
+            self._release_lock()
+
+    def _is_locked(self) -> bool:
+        return bool(self.redis.get(SYNC_WHATSAPP_CLOUD_MMLITE_STATUS_LOCK_KEY))
+
+    def _acquire_lock(self) -> None:
+        self.redis.set(SYNC_WHATSAPP_CLOUD_MMLITE_STATUS_LOCK_KEY, "1", ex=600)
+
+    def _release_lock(self) -> None:
+        self.redis.delete(SYNC_WHATSAPP_CLOUD_MMLITE_STATUS_LOCK_KEY)
+
+    def _group_candidates_by_waba(self) -> Dict[str, List[App]]:
+        # Django 3.2's .exclude on JSONField nested keys does not reliably
+        # include rows where the key is missing, so the predicate is applied
+        # in Python after a code-scoped DB filter.
+        wpp_cloud_apps = App.objects.filter(code=WPP_CLOUD_CODE)
+
+        grouped: Dict[str, List[App]] = defaultdict(list)
+        for app in wpp_cloud_apps:
+            config = app.config or {}
+            if config.get("mmlite_status") == MMLITE_STATUS_ACTIVE:
+                continue
+            waba_id = config.get("wa_waba_id")
+            if not waba_id:
+                continue
+            grouped[waba_id].append(app)
+        return grouped
+
+    def _has_active_sibling(self, waba_id: str) -> bool:
+        return App.objects.filter(
+            code=WPP_CLOUD_CODE,
+            config__wa_waba_id=waba_id,
+            config__mmlite_status=MMLITE_STATUS_ACTIVE,
+        ).exists()
+
+    def _process_waba_group(
+        self, waba_id: str, apps: List[App], summary: Dict[str, int]
+    ) -> None:
+        if self._has_active_sibling(waba_id):
+            logger.info(
+                f"Propagating mmlite_status=active to {len(apps)} app(s) "
+                f"sharing waba {waba_id} from already-active sibling."
+            )
+            for app in apps:
+                self._promote_app_to_active(app)
+            summary["propagated"] += len(apps)
+            return
+
+        meta_status = self._fetch_meta_status(waba_id, apps[0])
+        if meta_status == META_ONBOARDING_STATUS_ONBOARDED:
+            logger.info(
+                f"Meta reports waba {waba_id} as ONBOARDED. "
+                f"Flipping {len(apps)} app(s) to mmlite_status=active."
+            )
+            for app in apps:
+                self._promote_app_to_active(app)
+            summary["activated_via_meta"] += len(apps)
+        else:
+            logger.info(f"Meta reports waba {waba_id} as {meta_status!r}. Skipping.")
+            summary["skipped_not_onboarded"] += len(apps)
+
+    def _fetch_meta_status(
+        self, waba_id: str, representative_app: App
+    ) -> Optional[str]:
+        business_service = self._business_service_factory(representative_app)
+        response = business_service.get_mmlite_status(waba_id)
+        return response.get("marketing_messages_onboarding_status")
+
+    def _promote_app_to_active(self, app: App) -> None:
+        app.config["mmlite_status"] = MMLITE_STATUS_ACTIVE
+        app.save()
+
+        if not app.flow_object_uuid:
+            logger.info(
+                f"App {app.uuid} has no flow_object_uuid; skipping Flows config update."
+            )
+            return
+
+        try:
+            detail_channel = self.flows_client.detail_channel(app.flow_object_uuid)
+            flows_config = detail_channel.get("config") or {}
+            flows_config["mmlite"] = True
+            self.flows_client.update_config(
+                data=flows_config, flow_object_uuid=app.flow_object_uuid
+            )
+        except Exception as exc:
+            logger.error(f"Failed to update Flows config for app {app.uuid}: {exc}")
+            sentry_sdk.capture_exception(exc)
+
+    @staticmethod
+    def _default_business_service_factory(app: App) -> BusinessMetaService:
+        access_token = app.apptype.get_access_token(app)
+        return BusinessMetaService(client=FacebookClient(access_token))

--- a/marketplace/core/types/channels/whatsapp_cloud/usecases/mmlite_status_sync.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/usecases/mmlite_status_sync.py
@@ -77,6 +77,39 @@ class SyncMmliteStatusUseCase:
         finally:
             self._release_lock()
 
+    def sync_for_app(self, app: App) -> Dict[str, int]:
+        """Reconcile mmlite_status for a single app.
+
+        Used during channel creation and the manual PATCH to immediately check
+        Meta + propagate active status to Flows. Reuses the same WABA-deduplication
+        logic as the daily batch sync (sibling short-circuit + single Meta call).
+        """
+        summary = {
+            "candidates": 0,
+            "wabas": 0,
+            "propagated": 0,
+            "activated_via_meta": 0,
+            "skipped_not_onboarded": 0,
+            "errors": 0,
+        }
+        config = app.config or {}
+        if config.get("mmlite_status") == MMLITE_STATUS_ACTIVE:
+            return summary
+        waba_id = config.get("wa_waba_id")
+        if not waba_id:
+            logger.info(f"App {app.uuid} has no wa_waba_id; skipping MMLite sync.")
+            return summary
+
+        summary["candidates"] = 1
+        summary["wabas"] = 1
+        try:
+            self._process_waba_group(waba_id, [app], summary)
+        except Exception as exc:
+            summary["errors"] += 1
+            logger.error(f"Error syncing mmlite status for app {app.uuid}: {exc}")
+            sentry_sdk.capture_exception(exc)
+        return summary
+
     def _is_locked(self) -> bool:
         return bool(self.redis.get(SYNC_WHATSAPP_CLOUD_MMLITE_STATUS_LOCK_KEY))
 

--- a/marketplace/core/types/channels/whatsapp_cloud/usecases/tests/test_mmlite_status_sync.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/usecases/tests/test_mmlite_status_sync.py
@@ -1,0 +1,343 @@
+from uuid import uuid4
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from marketplace.applications.models import App
+from marketplace.core.types import APPTYPES
+from marketplace.core.types.channels.whatsapp_cloud.usecases.mmlite_status_sync import (
+    SYNC_WHATSAPP_CLOUD_MMLITE_STATUS_LOCK_KEY,
+    SyncMmliteStatusUseCase,
+)
+
+
+User = get_user_model()
+
+
+class SyncMmliteStatusUseCaseTestCase(TestCase):
+    def setUp(self) -> None:
+        self.admin_user = User.objects.get_admin_user()
+        self.wpp_cloud_type = APPTYPES.get("wpp-cloud")
+        self.waba_id = "waba-123"
+        self.other_waba_id = "waba-456"
+
+        self.redis_mock = MagicMock()
+        self.redis_mock.get.return_value = None
+
+        self.business_service_mock = MagicMock()
+        self.business_service_factory_mock = MagicMock(
+            return_value=self.business_service_mock
+        )
+
+        self.flows_client_mock = MagicMock()
+        self.flows_client_mock.detail_channel.return_value = {"config": {}}
+
+        return super().setUp()
+
+    def _build_use_case(self) -> SyncMmliteStatusUseCase:
+        return SyncMmliteStatusUseCase(
+            business_service_factory=self.business_service_factory_mock,
+            flows_client=self.flows_client_mock,
+            redis_connection=self.redis_mock,
+        )
+
+    _UNSET = object()
+
+    def _create_app(
+        self,
+        waba_id=None,
+        mmlite_status=None,
+        flow_object_uuid=_UNSET,
+        extra_config=None,
+    ) -> App:
+        config = {}
+        if waba_id is not None:
+            config["wa_waba_id"] = waba_id
+        if mmlite_status is not None:
+            config["mmlite_status"] = mmlite_status
+        if extra_config:
+            config.update(extra_config)
+
+        if flow_object_uuid is self._UNSET:
+            flow_object_uuid = uuid4()
+
+        return self.wpp_cloud_type.create_app(
+            config=config,
+            project_uuid=uuid4(),
+            flow_object_uuid=flow_object_uuid,
+            created_by=self.admin_user,
+        )
+
+    def test_execute_returns_none_when_locked(self):
+        self.redis_mock.get.return_value = "1"
+
+        result = self._build_use_case().execute()
+
+        self.assertIsNone(result)
+        self.redis_mock.set.assert_not_called()
+        self.business_service_factory_mock.assert_not_called()
+        self.flows_client_mock.detail_channel.assert_not_called()
+        self.flows_client_mock.update_config.assert_not_called()
+
+    def test_execute_acquires_and_releases_lock(self):
+        result = self._build_use_case().execute()
+
+        self.assertIsNotNone(result)
+        self.redis_mock.set.assert_called_once_with(
+            SYNC_WHATSAPP_CLOUD_MMLITE_STATUS_LOCK_KEY, "1", ex=600
+        )
+        self.redis_mock.delete.assert_called_once_with(
+            SYNC_WHATSAPP_CLOUD_MMLITE_STATUS_LOCK_KEY
+        )
+
+    def test_releases_lock_even_when_grouping_raises(self):
+        use_case = self._build_use_case()
+
+        with patch.object(
+            use_case, "_group_candidates_by_waba", side_effect=Exception("boom")
+        ):
+            with self.assertRaises(Exception):
+                use_case.execute()
+
+        self.redis_mock.delete.assert_called_once_with(
+            SYNC_WHATSAPP_CLOUD_MMLITE_STATUS_LOCK_KEY
+        )
+
+    def test_sibling_propagation_with_in_progress_status(self):
+        active_app = self._create_app(waba_id=self.waba_id, mmlite_status="active")
+        in_progress_app = self._create_app(
+            waba_id=self.waba_id, mmlite_status="in_progress"
+        )
+        self.flows_client_mock.detail_channel.return_value = {
+            "config": {"existing_key": "existing_value"}
+        }
+
+        summary = self._build_use_case().execute()
+
+        in_progress_app.refresh_from_db()
+        active_app.refresh_from_db()
+
+        self.assertEqual(in_progress_app.config["mmlite_status"], "active")
+        self.assertEqual(active_app.config["mmlite_status"], "active")
+
+        self.business_service_factory_mock.assert_not_called()
+        self.business_service_mock.get_mmlite_status.assert_not_called()
+
+        self.flows_client_mock.detail_channel.assert_called_once_with(
+            in_progress_app.flow_object_uuid
+        )
+        self.flows_client_mock.update_config.assert_called_once_with(
+            data={"existing_key": "existing_value", "mmlite": True},
+            flow_object_uuid=in_progress_app.flow_object_uuid,
+        )
+        self.assertEqual(summary["propagated"], 1)
+        self.assertEqual(summary["activated_via_meta"], 0)
+
+    def test_sibling_propagation_with_unset_status(self):
+        self._create_app(waba_id=self.waba_id, mmlite_status="active")
+        unset_app = self._create_app(waba_id=self.waba_id)
+
+        summary = self._build_use_case().execute()
+
+        unset_app.refresh_from_db()
+        self.assertEqual(unset_app.config["mmlite_status"], "active")
+        self.business_service_mock.get_mmlite_status.assert_not_called()
+        self.flows_client_mock.update_config.assert_called_once()
+        self.assertEqual(summary["propagated"], 1)
+
+    def test_meta_returns_onboarded_flips_all_apps_in_group(self):
+        app1 = self._create_app(waba_id=self.waba_id, mmlite_status="in_progress")
+        app2 = self._create_app(waba_id=self.waba_id)
+
+        self.business_service_mock.get_mmlite_status.return_value = {
+            "marketing_messages_onboarding_status": "ONBOARDED"
+        }
+
+        summary = self._build_use_case().execute()
+
+        app1.refresh_from_db()
+        app2.refresh_from_db()
+        self.assertEqual(app1.config["mmlite_status"], "active")
+        self.assertEqual(app2.config["mmlite_status"], "active")
+
+        self.business_service_factory_mock.assert_called_once()
+        self.business_service_mock.get_mmlite_status.assert_called_once_with(
+            self.waba_id
+        )
+        self.assertEqual(self.flows_client_mock.update_config.call_count, 2)
+        self.assertEqual(summary["activated_via_meta"], 2)
+        self.assertEqual(summary["propagated"], 0)
+        self.assertEqual(summary["skipped_not_onboarded"], 0)
+
+    def test_meta_returns_not_onboarded_does_not_flip(self):
+        app = self._create_app(waba_id=self.waba_id, mmlite_status="in_progress")
+        self.business_service_mock.get_mmlite_status.return_value = {
+            "marketing_messages_onboarding_status": "NOT_ONBOARDED"
+        }
+
+        summary = self._build_use_case().execute()
+
+        app.refresh_from_db()
+        self.assertEqual(app.config["mmlite_status"], "in_progress")
+        self.flows_client_mock.update_config.assert_not_called()
+        self.assertEqual(summary["skipped_not_onboarded"], 1)
+        self.assertEqual(summary["activated_via_meta"], 0)
+        self.assertEqual(summary["propagated"], 0)
+
+    def test_meta_call_raises_captures_and_continues(self):
+        app_failing = self._create_app(
+            waba_id=self.waba_id, mmlite_status="in_progress"
+        )
+        app_success = self._create_app(
+            waba_id=self.other_waba_id, mmlite_status="in_progress"
+        )
+
+        def fake_get_status(waba_id):
+            if waba_id == self.waba_id:
+                raise Exception("meta down")
+            return {"marketing_messages_onboarding_status": "ONBOARDED"}
+
+        self.business_service_mock.get_mmlite_status.side_effect = fake_get_status
+
+        with patch(
+            "marketplace.core.types.channels.whatsapp_cloud."
+            "usecases.mmlite_status_sync.sentry_sdk.capture_exception"
+        ) as mock_capture:
+            summary = self._build_use_case().execute()
+
+        app_failing.refresh_from_db()
+        app_success.refresh_from_db()
+
+        self.assertEqual(app_failing.config["mmlite_status"], "in_progress")
+        self.assertEqual(app_success.config["mmlite_status"], "active")
+        self.assertEqual(summary["errors"], 1)
+        self.assertEqual(summary["activated_via_meta"], 1)
+        mock_capture.assert_called_once()
+
+    def test_app_without_flow_object_uuid_is_flipped_without_flows_call(self):
+        app = self._create_app(
+            waba_id=self.waba_id,
+            mmlite_status="in_progress",
+            flow_object_uuid=None,
+        )
+        self.business_service_mock.get_mmlite_status.return_value = {
+            "marketing_messages_onboarding_status": "ONBOARDED"
+        }
+
+        summary = self._build_use_case().execute()
+
+        app.refresh_from_db()
+        self.assertEqual(app.config["mmlite_status"], "active")
+        self.flows_client_mock.detail_channel.assert_not_called()
+        self.flows_client_mock.update_config.assert_not_called()
+        self.assertEqual(summary["activated_via_meta"], 1)
+
+    def test_apps_without_waba_id_are_excluded(self):
+        no_waba_app = self._create_app(waba_id=None, mmlite_status="in_progress")
+        empty_waba_app = self._create_app(waba_id="", mmlite_status="in_progress")
+        active_only_app = self._create_app(waba_id=self.waba_id, mmlite_status="active")
+
+        summary = self._build_use_case().execute()
+
+        no_waba_app.refresh_from_db()
+        empty_waba_app.refresh_from_db()
+        active_only_app.refresh_from_db()
+
+        self.assertEqual(no_waba_app.config["mmlite_status"], "in_progress")
+        self.assertEqual(empty_waba_app.config["mmlite_status"], "in_progress")
+        self.assertEqual(active_only_app.config["mmlite_status"], "active")
+
+        self.business_service_mock.get_mmlite_status.assert_not_called()
+        self.assertEqual(summary["candidates"], 0)
+        self.assertEqual(summary["wabas"], 0)
+
+    def test_dedup_one_meta_call_per_waba(self):
+        for _ in range(3):
+            self._create_app(waba_id=self.waba_id, mmlite_status="in_progress")
+
+        self.business_service_mock.get_mmlite_status.return_value = {
+            "marketing_messages_onboarding_status": "NOT_ONBOARDED"
+        }
+
+        summary = self._build_use_case().execute()
+
+        self.assertEqual(self.business_service_mock.get_mmlite_status.call_count, 1)
+        self.business_service_mock.get_mmlite_status.assert_called_once_with(
+            self.waba_id
+        )
+        self.assertEqual(summary["candidates"], 3)
+        self.assertEqual(summary["wabas"], 1)
+        self.assertEqual(summary["skipped_not_onboarded"], 3)
+
+    def test_processes_multiple_wabas_independently(self):
+        self._create_app(waba_id=self.waba_id, mmlite_status="in_progress")
+        self._create_app(waba_id=self.other_waba_id, mmlite_status="in_progress")
+
+        responses = {
+            self.waba_id: {"marketing_messages_onboarding_status": "ONBOARDED"},
+            self.other_waba_id: {
+                "marketing_messages_onboarding_status": "NOT_ONBOARDED"
+            },
+        }
+        self.business_service_mock.get_mmlite_status.side_effect = (
+            lambda waba_id: responses[waba_id]
+        )
+
+        summary = self._build_use_case().execute()
+
+        self.assertEqual(summary["wabas"], 2)
+        self.assertEqual(summary["activated_via_meta"], 1)
+        self.assertEqual(summary["skipped_not_onboarded"], 1)
+        self.assertEqual(self.business_service_mock.get_mmlite_status.call_count, 2)
+
+    def test_flows_failure_does_not_revert_local_flip(self):
+        app = self._create_app(waba_id=self.waba_id, mmlite_status="in_progress")
+        self.business_service_mock.get_mmlite_status.return_value = {
+            "marketing_messages_onboarding_status": "ONBOARDED"
+        }
+        self.flows_client_mock.detail_channel.side_effect = Exception("flows down")
+
+        with patch(
+            "marketplace.core.types.channels.whatsapp_cloud."
+            "usecases.mmlite_status_sync.sentry_sdk.capture_exception"
+        ) as mock_capture:
+            summary = self._build_use_case().execute()
+
+        app.refresh_from_db()
+        self.assertEqual(app.config["mmlite_status"], "active")
+        self.assertEqual(summary["activated_via_meta"], 1)
+        self.assertEqual(summary["errors"], 0)
+        mock_capture.assert_called_once()
+
+    def test_default_business_service_factory_uses_app_access_token(self):
+        app = self._create_app(
+            waba_id=self.waba_id,
+            mmlite_status="in_progress",
+            extra_config={"wa_user_token": "custom-token"},
+        )
+
+        with patch(
+            "marketplace.core.types.channels.whatsapp_cloud."
+            "usecases.mmlite_status_sync.FacebookClient"
+        ) as mock_facebook_client_cls, patch(
+            "marketplace.core.types.channels.whatsapp_cloud."
+            "usecases.mmlite_status_sync.BusinessMetaService"
+        ) as mock_business_service_cls:
+            mock_business_service_cls.return_value.get_mmlite_status.return_value = {
+                "marketing_messages_onboarding_status": "NOT_ONBOARDED"
+            }
+
+            use_case = SyncMmliteStatusUseCase(
+                flows_client=self.flows_client_mock,
+                redis_connection=self.redis_mock,
+            )
+            use_case.execute()
+
+        mock_facebook_client_cls.assert_called_once_with("custom-token")
+        mock_business_service_cls.assert_called_once_with(
+            client=mock_facebook_client_cls.return_value
+        )
+        # ensure the app was fetched (sanity check)
+        app.refresh_from_db()
+        self.assertEqual(app.config["mmlite_status"], "in_progress")

--- a/marketplace/core/types/channels/whatsapp_cloud/usecases/tests/test_mmlite_status_sync.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/usecases/tests/test_mmlite_status_sync.py
@@ -341,3 +341,181 @@ class SyncMmliteStatusUseCaseTestCase(TestCase):
         # ensure the app was fetched (sanity check)
         app.refresh_from_db()
         self.assertEqual(app.config["mmlite_status"], "in_progress")
+
+
+class SyncMmliteStatusForAppTestCase(TestCase):
+    def setUp(self) -> None:
+        self.admin_user = User.objects.get_admin_user()
+        self.wpp_cloud_type = APPTYPES.get("wpp-cloud")
+        self.waba_id = "waba-123"
+
+        self.redis_mock = MagicMock()
+        self.redis_mock.get.return_value = None
+
+        self.business_service_mock = MagicMock()
+        self.business_service_factory_mock = MagicMock(
+            return_value=self.business_service_mock
+        )
+
+        self.flows_client_mock = MagicMock()
+        self.flows_client_mock.detail_channel.return_value = {"config": {}}
+
+        return super().setUp()
+
+    def _build_use_case(self) -> SyncMmliteStatusUseCase:
+        return SyncMmliteStatusUseCase(
+            business_service_factory=self.business_service_factory_mock,
+            flows_client=self.flows_client_mock,
+            redis_connection=self.redis_mock,
+        )
+
+    _UNSET = object()
+
+    def _create_app(
+        self,
+        waba_id=None,
+        mmlite_status=None,
+        flow_object_uuid=_UNSET,
+        extra_config=None,
+    ) -> App:
+        config = {}
+        if waba_id is not None:
+            config["wa_waba_id"] = waba_id
+        if mmlite_status is not None:
+            config["mmlite_status"] = mmlite_status
+        if extra_config:
+            config.update(extra_config)
+
+        if flow_object_uuid is self._UNSET:
+            flow_object_uuid = uuid4()
+
+        return self.wpp_cloud_type.create_app(
+            config=config,
+            project_uuid=uuid4(),
+            flow_object_uuid=flow_object_uuid,
+            created_by=self.admin_user,
+        )
+
+    def test_sync_for_app_returns_early_when_already_active(self):
+        app = self._create_app(waba_id=self.waba_id, mmlite_status="active")
+
+        summary = self._build_use_case().sync_for_app(app)
+
+        self.assertEqual(summary["candidates"], 0)
+        self.assertEqual(summary["wabas"], 0)
+        self.assertEqual(summary["activated_via_meta"], 0)
+        self.assertEqual(summary["propagated"], 0)
+        self.business_service_factory_mock.assert_not_called()
+        self.business_service_mock.get_mmlite_status.assert_not_called()
+        self.flows_client_mock.detail_channel.assert_not_called()
+        self.flows_client_mock.update_config.assert_not_called()
+
+    def test_sync_for_app_returns_early_when_no_waba_id(self):
+        app = self._create_app(waba_id=None, mmlite_status="in_progress")
+
+        summary = self._build_use_case().sync_for_app(app)
+
+        self.assertEqual(summary["candidates"], 0)
+        self.assertEqual(summary["wabas"], 0)
+        self.business_service_factory_mock.assert_not_called()
+        self.business_service_mock.get_mmlite_status.assert_not_called()
+        self.flows_client_mock.detail_channel.assert_not_called()
+
+    def test_sync_for_app_returns_early_when_empty_waba_id(self):
+        app = self._create_app(waba_id="", mmlite_status="in_progress")
+
+        summary = self._build_use_case().sync_for_app(app)
+
+        self.assertEqual(summary["candidates"], 0)
+        self.business_service_mock.get_mmlite_status.assert_not_called()
+
+    def test_sync_for_app_promotes_when_meta_onboarded(self):
+        app = self._create_app(waba_id=self.waba_id, mmlite_status="in_progress")
+        self.business_service_mock.get_mmlite_status.return_value = {
+            "marketing_messages_onboarding_status": "ONBOARDED"
+        }
+        self.flows_client_mock.detail_channel.return_value = {
+            "config": {"existing_key": "existing_value"}
+        }
+
+        summary = self._build_use_case().sync_for_app(app)
+
+        app.refresh_from_db()
+        self.assertEqual(app.config["mmlite_status"], "active")
+        self.assertEqual(summary["candidates"], 1)
+        self.assertEqual(summary["wabas"], 1)
+        self.assertEqual(summary["activated_via_meta"], 1)
+        self.assertEqual(summary["propagated"], 0)
+
+        self.business_service_mock.get_mmlite_status.assert_called_once_with(
+            self.waba_id
+        )
+        self.flows_client_mock.update_config.assert_called_once_with(
+            data={"existing_key": "existing_value", "mmlite": True},
+            flow_object_uuid=app.flow_object_uuid,
+        )
+
+    def test_sync_for_app_propagates_from_active_sibling(self):
+        self._create_app(waba_id=self.waba_id, mmlite_status="active")
+        new_app = self._create_app(waba_id=self.waba_id, mmlite_status="in_progress")
+
+        summary = self._build_use_case().sync_for_app(new_app)
+
+        new_app.refresh_from_db()
+        self.assertEqual(new_app.config["mmlite_status"], "active")
+        self.assertEqual(summary["propagated"], 1)
+        self.assertEqual(summary["activated_via_meta"], 0)
+        self.business_service_factory_mock.assert_not_called()
+        self.business_service_mock.get_mmlite_status.assert_not_called()
+        self.flows_client_mock.update_config.assert_called_once()
+
+    def test_sync_for_app_skips_when_meta_not_onboarded(self):
+        app = self._create_app(waba_id=self.waba_id, mmlite_status="in_progress")
+        self.business_service_mock.get_mmlite_status.return_value = {
+            "marketing_messages_onboarding_status": "NOT_ONBOARDED"
+        }
+
+        summary = self._build_use_case().sync_for_app(app)
+
+        app.refresh_from_db()
+        self.assertEqual(app.config["mmlite_status"], "in_progress")
+        self.assertEqual(summary["skipped_not_onboarded"], 1)
+        self.assertEqual(summary["activated_via_meta"], 0)
+        self.flows_client_mock.update_config.assert_not_called()
+
+    def test_sync_for_app_captures_meta_exception(self):
+        app = self._create_app(waba_id=self.waba_id, mmlite_status="in_progress")
+        self.business_service_mock.get_mmlite_status.side_effect = Exception(
+            "meta down"
+        )
+
+        with patch(
+            "marketplace.core.types.channels.whatsapp_cloud."
+            "usecases.mmlite_status_sync.sentry_sdk.capture_exception"
+        ) as mock_capture:
+            summary = self._build_use_case().sync_for_app(app)
+
+        app.refresh_from_db()
+        self.assertEqual(app.config["mmlite_status"], "in_progress")
+        self.assertEqual(summary["errors"], 1)
+        self.assertEqual(summary["activated_via_meta"], 0)
+        self.flows_client_mock.update_config.assert_not_called()
+        mock_capture.assert_called_once()
+
+    def test_sync_for_app_skips_flows_when_no_flow_object_uuid(self):
+        app = self._create_app(
+            waba_id=self.waba_id,
+            mmlite_status="in_progress",
+            flow_object_uuid=None,
+        )
+        self.business_service_mock.get_mmlite_status.return_value = {
+            "marketing_messages_onboarding_status": "ONBOARDED"
+        }
+
+        summary = self._build_use_case().sync_for_app(app)
+
+        app.refresh_from_db()
+        self.assertEqual(app.config["mmlite_status"], "active")
+        self.assertEqual(summary["activated_via_meta"], 1)
+        self.flows_client_mock.detail_channel.assert_not_called()
+        self.flows_client_mock.update_config.assert_not_called()

--- a/marketplace/core/types/channels/whatsapp_cloud/views.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/views.py
@@ -22,6 +22,9 @@ from marketplace.core.types.channels.whatsapp.usecases.phone_number_sync import 
     PhoneNumberSyncUseCase,
 )
 from marketplace.core.types.channels.whatsapp.usecases.waba_sync import WABASyncUseCase
+from marketplace.core.types.channels.whatsapp_cloud.usecases.mmlite_status_sync import (
+    SyncMmliteStatusUseCase,
+)
 from marketplace.core.types.channels.whatsapp_cloud.usecases.whatsapp_insights_sync import (
     WhatsAppInsightsSyncUseCase,
 )
@@ -169,6 +172,7 @@ class WhatsAppCloudViewSet(
         WABASyncUseCase(app).sync_whatsapp_cloud_waba()
         PhoneNumberSyncUseCase(app).sync_whatsapp_cloud_phone_number()
         WhatsAppInsightsSyncUseCase(app).sync()
+        SyncMmliteStatusUseCase().sync_for_app(app)
 
         response_data = {
             **serializer.validated_data,
@@ -244,35 +248,16 @@ class WhatsAppCloudViewSet(
     def update_mmlite_status(self, request: "Request", **kwargs):
         app = self.get_object()
 
-        status = request.data.get("status")
+        requested_status = request.data.get("status")
 
-        if status not in ["in_progress", "active"]:
+        if requested_status not in ["in_progress", "active"]:
             raise ValidationError("Invalid status")
 
-        # request meta to check if mmlite is already active
-        facebook_client = FacebookClient(app.apptype.get_access_token(app))
-        business_service = BusinessMetaService(client=facebook_client)
+        summary = SyncMmliteStatusUseCase().sync_for_app(app)
 
-        waba_id = app.config.get("wa_waba_id")
-        mmlite_status = business_service.get_mmlite_status(waba_id)
-
-        # if mmlite is already active, update locally and flows channel config
-        if mmlite_status.get("marketing_messages_onboarding_status") == "ONBOARDED":
-            app.config["mmlite_status"] = "active"
-
-            flows_client = FlowsClient()
-            detail_channel = flows_client.detail_channel(app.flow_object_uuid)
-
-            flows_config = detail_channel["config"]
-            updated_config = flows_config
-            updated_config["mmlite"] = True
-            flows_client.update_config(
-                data=updated_config, flow_object_uuid=app.flow_object_uuid
-            )
-        else:
-            app.config["mmlite_status"] = request.data.get("status")
-
-        app.save()
+        if summary["activated_via_meta"] == 0 and summary["propagated"] == 0:
+            app.config["mmlite_status"] = requested_status
+            app.save()
 
         serializer = self.get_serializer(app)
         return Response(serializer.data)

--- a/marketplace/settings.py
+++ b/marketplace/settings.py
@@ -359,6 +359,13 @@ CELERY_BEAT_SCHEDULE = {
         "task": "sync_whatsapp_cloud_apps",
         "schedule": timedelta(hours=2),
     },
+    "sync-whatsapp-cloud-mmlite-status": {
+        "task": "sync_whatsapp_cloud_mmlite_status",
+        "schedule": crontab(
+            minute=0,
+            hour=env.int("SYNC_WHATSAPP_CLOUD_MMLITE_STATUS_HOUR", default=1),
+        ),
+    },
     "sync-whatsapp-wabas": {
         "task": "sync_whatsapp_wabas",
         "schedule": crontab(

--- a/marketplace/swagger.py
+++ b/marketplace/swagger.py
@@ -6,7 +6,7 @@ from rest_framework import permissions
 view = get_schema_view(
     openapi.Info(
         title="Integrations API Documentation",
-        default_version="v4.18.3",
+        default_version="v4.19.0",
         desccription="Documentation of the Integrations APIs",
     ),
     public=True,


### PR DESCRIPTION
### What

Reconciles `mmlite_status` for WhatsApp Cloud (`wpp-cloud`) apps against Meta on three triggers — a daily batch task, channel creation, and the manual PATCH endpoint — through a single shared use case (`SyncMmliteStatusUseCase` in `marketplace/core/types/channels/whatsapp_cloud/usecases/mmlite_status_sync.py`):

- `execute()` runs daily via `sync_whatsapp_cloud_mmlite_status` (registered in `CELERY_BEAT_SCHEDULE` with `SYNC_WHATSAPP_CLOUD_MMLITE_STATUS_HOUR`, default 1). Groups inactive apps by `wa_waba_id` so each WABA is queried at most once. If a sibling app on the same WABA is already `active`, the rest are flipped without a Meta call; otherwise one `BusinessMetaService.get_mmlite_status(waba_id)` call drives the decision (`ONBOARDED` → flip all). Redis-locked, per-WABA `try/except` + Sentry, returns a counters summary.
- `sync_for_app(app)` is called from `WhatsAppCloudViewSet.create()` right after the existing usecase chain, and from a refactored `update_mmlite_status` PATCH that now delegates to it (falling back to the user-submitted status when Meta neither activates nor propagates). Reuses the same `_process_waba_group` so per-app syncs share sibling-propagation + single-Meta-call logic. No Redis lock; internal `try/except` + Sentry so Meta/Flows outages don't break the request.

Whenever an app flips to `active` (any trigger), `mmlite: True` is also pushed to the Flows channel config via `FlowsClient.detail_channel` + `update_config`. Flows failures are captured to Sentry but don't revert the local flip.

Behavior change to flag: when Meta is down during PATCH, the old code returned HTTP 500 with no local update. The new PATCH captures the error to Sentry and falls through to writing the user-submitted status, matching how the daily task and create-flow handle Meta outages.

Tests cover the batch path (lock, sibling propagation, Meta `ONBOARDED`/`NOT_ONBOARDED`, exception continuation, Flows failure, no `flow_object_uuid`, missing/empty `wa_waba_id`, 3-apps→1-call dedup, multi-WABA, default factory) and the per-app path (`SyncMmliteStatusForAppTestCase` mirroring those cases). View tests redirect their patches to the use case module so existing PATCH coverage exercises the shared path; new tests cover the Meta-down PATCH fallback and `create()` invoking `sync_for_app` for the new app. Plus a delegation test for the Celery task.

No model migrations; only one new env var: `SYNC_WHATSAPP_CLOUD_MMLITE_STATUS_HOUR`.

### Why

MMLite onboarding status reaches us via Meta webhooks and a manual PATCH, but webhook delivery isn't guaranteed: missed events leave apps stuck on `in_progress`/unset even after Meta has flipped them to `ONBOARDED`. The daily task closes that gap with at most one Meta call per distinct WABA and zero when a sibling already reflects active. Syncing at channel creation closes the same gap from the other side — a new app on an already-onboarded WABA otherwise sits on an unset status until the next webhook or nightly run. Routing the PATCH through the same use case removes the third copy of the Meta + Flows logic and gives all triggers identical handling for sibling propagation and Meta outages.
