### PR TITLE
feat: Expose phone_number.id on wpp-cloud app detail

### DIFF
--- a/marketplace/core/types/channels/whatsapp_base/serializers.py
+++ b/marketplace/core/types/channels/whatsapp_base/serializers.py
@@ -29,6 +29,7 @@ class WhatsAppConfigWABASerializer(serializers.Serializer):
 
 
 class WhatsAppConfigPhoneNumberSerializer(serializers.Serializer):
+    id = serializers.CharField()
     display_name = serializers.CharField()
     display_phone_number = serializers.CharField()
     consent_status = serializers.CharField(required=False)

--- a/marketplace/core/types/channels/whatsapp_cloud/tests/test_views.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/tests/test_views.py
@@ -66,6 +66,39 @@ class RetrieveWhatsAppCloudTestCase(APIBaseTestCase):
         self.assertIn("created_on", response.json)
         self.assertEqual(response.json["config"], {})
 
+    def test_retrieve_exposes_phone_number_id_and_waba_id(self):
+        self.app.config = {
+            "title": "+55 11 2148-4999",
+            "waba": {
+                "id": "912460154934195",
+                "name": "Agentic CX Staging",
+                "timezone_id": "24",
+                "message_template_namespace": "08097e0b_5d0c_4661_8f59_467c55225a22",
+            },
+            "phone_number": {
+                "id": "1089390800916485",
+                "display_name": "Agentic CX Staging",
+                "display_phone_number": "+55 11 2148-4999",
+            },
+            "wa_business_id": "1064679703605727",
+            "wa_phone_number_id": "1089390800916485",
+        }
+        self.app.save()
+
+        response = self.request.get(self.url, uuid=self.app.uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        config = response.json["config"]
+        self.assertEqual(config["phone_number"]["id"], "1089390800916485")
+        self.assertEqual(
+            config["phone_number"]["display_phone_number"], "+55 11 2148-4999"
+        )
+        self.assertEqual(config["phone_number"]["display_name"], "Agentic CX Staging")
+        self.assertEqual(config["waba"]["id"], "912460154934195")
+
+        self.assertNotIn("wa_phone_number_id", config)
+
 
 class DestroyWhatsAppCloudTestCase(APIBaseTestCase):
     view_class = WhatsAppCloudViewSet


### PR DESCRIPTION
## What
Add `id` to `WhatsAppConfigPhoneNumberSerializer` so
`GET /api/v1/apptypes/wpp-cloud/apps/{app_uuid}/` returns
`config.phone_number.id` (Meta Phone Number ID).

## Why
Consumers need the Meta Phone Number ID to call the WhatsApp
Cloud Graph API. The value is already persisted in `app.config`
but was filtered out by the detail endpoint's serializer.