### PR TITLE
feat(whatsapp): add direct_send field to WhatsAppConfigSerializer

### DIFF
--- a/marketplace/core/types/channels/whatsapp_base/serializers.py
+++ b/marketplace/core/types/channels/whatsapp_base/serializers.py
@@ -43,6 +43,7 @@ class WhatsAppConfigSerializer(serializers.Serializer):
     wa_business_id = serializers.CharField(required=False)
     mmlite_status = serializers.CharField(required=False)
     has_calling = serializers.BooleanField(required=False)
+    direct_send = serializers.BooleanField(required=False)
 
 
 class WhatsAppSerializer(AppTypeBaseSerializer):


### PR DESCRIPTION
### What
Expose direct_send flag to the API response

### Why
Retail needs this information when when assigning agents