### PR TITLE
feat: Implement template category notification handling

### DIFF
--- a/marketplace/clients/commerce/client.py
+++ b/marketplace/clients/commerce/client.py
@@ -33,3 +33,11 @@ class CommerceClient(RequestClient, CommerceClientInterface):
             json=payload,
         )
         return response
+
+    def send_template_category_notification(self, data):
+        url = f"{self.base_url}/webhook/templates-status/api/category-notification/"
+
+        response = self.make_request(
+            url, method="POST", headers=self.authentication_instance.headers, json=data
+        )
+        return response.json()

--- a/marketplace/core/types/channels/whatsapp_cloud/tasks.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/tasks.py
@@ -93,7 +93,7 @@ def update_account_info_by_webhook(**kwargs):  # pragma: no cover
             if value.get("reason", None) is None:
                 value["reason"] = ""
 
-            whatsapp_business_account_id = value.get("waba_info", {}).get("waba_id")
+            whatsapp_business_account_id = value.get("waba_info", {}).get("waba_id") or entry.get("id", "")
             if not whatsapp_business_account_id:
                 logger.info(
                     f"Whatsapp business account id not found in webhook data: {webhook_data}"

--- a/marketplace/core/types/channels/whatsapp_cloud/tasks.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/tasks.py
@@ -93,7 +93,7 @@ def update_account_info_by_webhook(**kwargs):  # pragma: no cover
             if value.get("reason", None) is None:
                 value["reason"] = ""
 
-            whatsapp_business_account_id = value.get("waba_info", {}).get("waba_id") or entry.get("id", "")
+            whatsapp_business_account_id = value.get("waba_info", {}).get("waba_id")
             if not whatsapp_business_account_id:
                 logger.info(
                     f"Whatsapp business account id not found in webhook data: {webhook_data}"

--- a/marketplace/interfaces/commerce/interfaces.py
+++ b/marketplace/interfaces/commerce/interfaces.py
@@ -38,3 +38,19 @@ class CommerceClientInterface(ABC):
             Dictionary with the API response.
         """
         pass
+
+    @abstractmethod
+    def send_template_category_notification(
+        self, data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Send template category-detection notification to Commerce API.
+
+        Args:
+            data: Dictionary containing project_uuid, app_uuid, template_name,
+                template_category and template_correct_category.
+
+        Returns:
+            Dictionary with the API response.
+        """
+        pass

--- a/marketplace/services/commerce/service.py
+++ b/marketplace/services/commerce/service.py
@@ -33,3 +33,16 @@ class CommerceService:
         Send template version to Commerce API.
         """
         return self.client.send_gallery_template_version(gallery_version_uuid, status)
+
+    def send_template_category_notification(self, data: dict) -> dict:
+        """
+        Forward a template category-detection notification to Commerce API.
+
+        Args:
+            data: Payload with project_uuid, app_uuid, template_name,
+                template_category and template_correct_category.
+
+        Returns:
+            Dictionary with the API response.
+        """
+        return self.client.send_template_category_notification(data)

--- a/marketplace/services/commerce/tests/test_service.py
+++ b/marketplace/services/commerce/tests/test_service.py
@@ -1,0 +1,44 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from marketplace.services.commerce.service import CommerceService
+
+
+class CommerceServiceTestCase(TestCase):
+    def setUp(self):
+        self.client = MagicMock()
+        self.service = CommerceService(client=self.client)
+
+    def test_send_template_library_status_update_delegates_to_client(self):
+        self.client.send_template_library_status_update.return_value = {"ok": True}
+        data = {"foo": "bar"}
+
+        result = self.service.send_template_library_status_update(data)
+
+        self.client.send_template_library_status_update.assert_called_once_with(data)
+        self.assertEqual(result, {"ok": True})
+
+    def test_send_gallery_template_version_delegates_to_client(self):
+        self.client.send_gallery_template_version.return_value = {"ok": True}
+
+        result = self.service.send_gallery_template_version("gallery-uuid", "APPROVED")
+
+        self.client.send_gallery_template_version.assert_called_once_with(
+            "gallery-uuid", "APPROVED"
+        )
+        self.assertEqual(result, {"ok": True})
+
+    def test_send_template_category_notification_delegates_to_client(self):
+        self.client.send_template_category_notification.return_value = {"ok": True}
+        payload = {
+            "project_uuid": "proj-uuid-123",
+            "app_uuid": "app-uuid-456",
+            "template_name": "order_confirmation",
+            "template_category": "UTILITY",
+            "template_correct_category": "MARKETING",
+        }
+
+        result = self.service.send_template_category_notification(payload)
+
+        self.client.send_template_category_notification.assert_called_once_with(payload)
+        self.assertEqual(result, {"ok": True})

--- a/marketplace/wpp_templates/factories.py
+++ b/marketplace/wpp_templates/factories.py
@@ -6,6 +6,7 @@ from marketplace.wpp_templates.usecases.template_library_status import (
     TemplateLibraryStatusUseCase,
 )
 from marketplace.wpp_templates.utils import (
+    TemplateCategoryChangeHandler,
     TemplateStatusUpdateHandler,
     TemplateWebhookEventProcessor,
 )
@@ -19,10 +20,16 @@ def create_template_webhook_event_processor() -> TemplateWebhookEventProcessor:
     flows_service = FlowsService(FlowsClient())
     commerce_service = CommerceService(CommerceClient())
 
-    handler = TemplateStatusUpdateHandler(
+    status_update_handler = TemplateStatusUpdateHandler(
         flows_service=flows_service,
         commerce_service=commerce_service,
         status_use_case_factory=create_status_use_case,
     )
+    category_change_handler = TemplateCategoryChangeHandler(
+        commerce_service=commerce_service,
+    )
 
-    return TemplateWebhookEventProcessor(handler=handler)
+    return TemplateWebhookEventProcessor(
+        status_update_handler=status_update_handler,
+        category_change_handler=category_change_handler,
+    )

--- a/marketplace/wpp_templates/tasks.py
+++ b/marketplace/wpp_templates/tasks.py
@@ -82,7 +82,10 @@ def update_templates_by_webhook(**kwargs):  # pragma: no cover
         - Mapped and unmapped event types.
         - Processing results for each app/template.
     """
-    allowed_event_types = ["message_template_status_update"]
+    allowed_event_types = [
+        "message_template_status_update",
+        "template_correct_category_detection",
+    ]
     webhook_data = kwargs.get("webhook_data")
 
     logger.info(f"Update templates by webhook data received: {webhook_data}")

--- a/marketplace/wpp_templates/tests/test_utils.py
+++ b/marketplace/wpp_templates/tests/test_utils.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, MagicMock
 from datetime import datetime
 
 from marketplace.wpp_templates.utils import (
+    TemplateCategoryChangeHandler,
     TemplateWebhookEventProcessor,
     extract_template_data,
 )
@@ -19,14 +20,18 @@ class TestTemplateWebhookEventProcessor(TestCase):
         self.mock_template_filter = patch(
             "marketplace.wpp_templates.utils.TemplateMessage.objects.filter"
         ).start()
-        self.handler = MagicMock()
-        self.processor = TemplateWebhookEventProcessor(handler=self.handler)
+        self.status_update_handler = MagicMock()
+        self.category_change_handler = MagicMock()
+        self.processor = TemplateWebhookEventProcessor(
+            status_update_handler=self.status_update_handler,
+            category_change_handler=self.category_change_handler,
+        )
         self.addCleanup(patch.stopall)
 
     def test_process_template_status_update_no_apps(self):
         self.mock_app_filter.return_value.exists.return_value = False
         self.processor.process_template_status_update("123", {}, {})
-        self.handler.handle.assert_not_called()
+        self.status_update_handler.handle.assert_not_called()
 
     def test_process_template_status_update_with_apps(self):
         mock_app = MagicMock()
@@ -49,7 +54,7 @@ class TestTemplateWebhookEventProcessor(TestCase):
             {},
         )
 
-        self.handler.handle.assert_called_once()
+        self.status_update_handler.handle.assert_called_once()
 
     def test_skips_if_template_is_none(self):
         mock_app = MagicMock()
@@ -67,7 +72,7 @@ class TestTemplateWebhookEventProcessor(TestCase):
             },
             {},
         )
-        self.handler.handle.assert_not_called()
+        self.status_update_handler.handle.assert_not_called()
 
     def test_unexpected_error_logs(self):
         mock_app = MagicMock()
@@ -95,6 +100,100 @@ class TestTemplateWebhookEventProcessor(TestCase):
             "waba", {"event": "APPROVED"}, "message_template_status_update", {}
         )
         self.processor.process_template_status_update.assert_called_once()
+
+    def test_process_template_category_change_no_apps(self):
+        self.mock_app_filter.return_value.exists.return_value = False
+
+        self.processor.process_template_category_change(
+            "waba-1",
+            {
+                "message_template_name": "order_confirmation",
+                "category": "UTILITY",
+                "correct_category": "MARKETING",
+            },
+        )
+
+        self.category_change_handler.handle.assert_not_called()
+
+    def test_process_template_category_change_delegates_per_app(self):
+        app_one = MagicMock()
+        app_two = MagicMock()
+
+        self.mock_app_filter.return_value.exists.return_value = True
+        self.mock_app_filter.return_value.__iter__.return_value = [app_one, app_two]
+
+        value = {
+            "message_template_name": "order_confirmation",
+            "category": "UTILITY",
+            "correct_category": "MARKETING",
+        }
+        self.processor.process_template_category_change("waba-1", value)
+
+        self.assertEqual(self.category_change_handler.handle.call_count, 2)
+        self.category_change_handler.handle.assert_any_call(app=app_one, value=value)
+        self.category_change_handler.handle.assert_any_call(app=app_two, value=value)
+
+    def test_process_event_routes_template_correct_category_detection(self):
+        self.processor.process_template_category_change = MagicMock()
+
+        self.processor.process_event(
+            "waba-1",
+            {
+                "message_template_name": "order_confirmation",
+                "category": "UTILITY",
+                "correct_category": "MARKETING",
+            },
+            "template_correct_category_detection",
+            {},
+        )
+
+        self.processor.process_template_category_change.assert_called_once_with(
+            "waba-1",
+            {
+                "message_template_name": "order_confirmation",
+                "category": "UTILITY",
+                "correct_category": "MARKETING",
+            },
+        )
+
+
+class TestTemplateCategoryChangeHandler(TestCase):
+    def setUp(self):
+        self.commerce_service = MagicMock()
+        self.handler = TemplateCategoryChangeHandler(
+            commerce_service=self.commerce_service
+        )
+        self.app = MagicMock()
+        self.app.uuid = "app-uuid-1"
+        self.app.project_uuid = "proj-uuid-1"
+        self.value = {
+            "message_template_name": "order_confirmation",
+            "category": "UTILITY",
+            "correct_category": "MARKETING",
+        }
+
+    def test_handle_sends_payload_to_commerce(self):
+        self.handler.handle(app=self.app, value=self.value)
+
+        self.commerce_service.send_template_category_notification.assert_called_once_with(
+            {
+                "project_uuid": "proj-uuid-1",
+                "app_uuid": "app-uuid-1",
+                "template_name": "order_confirmation",
+                "template_category": "UTILITY",
+                "template_correct_category": "MARKETING",
+            }
+        )
+
+    def test_handle_logs_and_does_not_raise_on_commerce_error(self):
+        self.commerce_service.send_template_category_notification.side_effect = (
+            Exception("commerce down")
+        )
+        self.handler.logger = MagicMock()
+
+        self.handler.handle(app=self.app, value=self.value)
+
+        self.handler.logger.error.assert_called_once()
 
 
 class TestExtractTemplateData(TestCase):

--- a/marketplace/wpp_templates/utils.py
+++ b/marketplace/wpp_templates/utils.py
@@ -125,13 +125,56 @@ class TemplateStatusUpdateHandler:
             )
 
 
+class TemplateCategoryChangeHandler:
+    def __init__(
+        self,
+        commerce_service: "CommerceService",
+        logger: Optional[logging.Logger] = None,
+    ):
+        self.commerce_service = commerce_service
+        self.logger = logger or logging.getLogger(__name__)
+
+    def handle(self, app: App, value: dict) -> None:
+        """
+        Proxy a Facebook `template_correct_category_detection` event to Commerce.
+
+        No local DB writes are performed; the event is forwarded so Commerce can
+        react to category mismatches. Errors from Commerce are logged and
+        swallowed so a single app failure does not break processing for sibling
+        apps sharing the same WABA.
+        """
+        payload = self._build_payload(app, value)
+        try:
+            self.commerce_service.send_template_category_notification(payload)
+            self.logger.info(
+                f"[Commerce] Template category notification sent for App {str(app.uuid)}, "
+                f"template: {payload['template_name']}."
+            )
+        except Exception as e:
+            self.logger.error(
+                f"[Commerce] Failed to send template category notification for App {str(app.uuid)}, "
+                f"template: {payload['template_name']}, error: {e}"
+            )
+
+    def _build_payload(self, app: App, value: dict) -> dict:
+        return {
+            "project_uuid": str(app.project_uuid),
+            "app_uuid": str(app.uuid),
+            "template_name": value.get("message_template_name"),
+            "template_category": value.get("category"),
+            "template_correct_category": value.get("correct_category"),
+        }
+
+
 class TemplateWebhookEventProcessor:
     def __init__(
         self,
-        handler: TemplateStatusUpdateHandler,
+        status_update_handler: TemplateStatusUpdateHandler,
+        category_change_handler: TemplateCategoryChangeHandler,
         logger: Optional[logging.Logger] = None,
     ):
-        self.handler = handler
+        self.status_update_handler = status_update_handler
+        self.category_change_handler = category_change_handler
         self.logger = logger or logging.getLogger(__name__)
 
     def get_apps_by_waba_id(self, waba_id: str):
@@ -163,7 +206,7 @@ class TemplateWebhookEventProcessor:
                     message_template_id=message_template_id,
                 )
                 for translation in translations:
-                    self.handler.handle(
+                    self.status_update_handler.handle(
                         app=app,
                         template=template,
                         translation=translation,
@@ -175,11 +218,22 @@ class TemplateWebhookEventProcessor:
                     f"Unexpected error processing template status update for App {str(app.uuid)}: {e}"
                 )
 
+    def process_template_category_change(self, waba_id: str, value: dict) -> None:
+        apps = self.get_apps_by_waba_id(waba_id)
+        if not apps.exists():
+            self.logger.info(f"There are no applications linked to waba: {waba_id}")
+            return
+
+        for app in apps:
+            self.category_change_handler.handle(app=app, value=value)
+
     def process_event(
         self, waba_id: str, value: dict, event_type: str, webhook: dict
     ) -> None:
         if event_type == "message_template_status_update":
             self.process_template_status_update(waba_id, value, webhook)
+        elif event_type == "template_correct_category_detection":
+            self.process_template_category_change(waba_id, value)
 
 
 def extract_template_data(translation: TemplateTranslation) -> dict:


### PR DESCRIPTION
### What

Proxy the new Facebook `template_correct_category_detection` webhook event to Commerce at `POST /webhook/templates-status/api/category-notification/`. For each App linked to the incoming WABA id, a payload with `project_uuid`, `app_uuid`, `template_name`, `template_category` and `template_correct_category` is forwarded. No local DB writes.

Routing follows the existing `update_templates_by_webhook` Celery flow: the `TemplateWebhookEventProcessor` dispatches the new field to a dedicated `TemplateCategoryChangeHandler` that owns the per-app side effect (payload build + Commerce call + error swallow), mirroring the layering used by `TemplateStatusUpdateHandler`.

### Why

Meta started emitting category-mismatch detections for WhatsApp templates, and Commerce needs that signal to react. Integrations-engine is the only service that already receives WhatsApp template webhooks from Meta and knows the WABA-id → App / Project mapping, so it is the natural proxy point — Commerce gets the contextual identifiers it cannot resolve on its own.
