### PR TITLE
feat: Add position attribute to WWC widget configuration

### DIFF
--- a/marketplace/core/types/channels/weni_web_chat/serializers.py
+++ b/marketplace/core/types/channels/weni_web_chat/serializers.py
@@ -17,6 +17,10 @@ from . import type as type_
 from marketplace.clients.flows.client import FlowsClient
 
 
+WIDGET_POSITIONS = ("bottom-right", "bottom-left")
+DEFAULT_WIDGET_POSITION = "bottom-right"
+
+
 class WeniWebChatSerializer(AppTypeBaseSerializer):
     class Meta:
         model = App
@@ -92,6 +96,19 @@ class OpenLauncherImageField(serializers.Field):
         raise ValidationError("Expected a base64 image string or a URL.")
 
 
+class WidgetPositionField(serializers.ChoiceField):
+    """Page corner where the widget is anchored.
+
+    An empty value falls back to the default so apps that send an empty
+    string keep rendering at the default corner instead of being rejected.
+    """
+
+    def to_internal_value(self, data):
+        if data == "":
+            return self.default
+        return super().to_internal_value(data)
+
+
 class ConfigSerializer(serializers.Serializer):
     title = serializers.CharField(required=True)
     subtitle = serializers.CharField(required=False, allow_blank=True)
@@ -122,6 +139,9 @@ class ConfigSerializer(serializers.Serializer):
     )
     voiceMode = serializers.JSONField(required=False)
     addToCart = serializers.BooleanField(default=False)
+    position = WidgetPositionField(
+        choices=WIDGET_POSITIONS, default=DEFAULT_WIDGET_POSITION
+    )
 
     @staticmethod
     def _is_stored_url(value):

--- a/marketplace/core/types/channels/weni_web_chat/tests/test_views.py
+++ b/marketplace/core/types/channels/weni_web_chat/tests/test_views.py
@@ -545,6 +545,107 @@ class ConfigureWeniWebChatTestCase(PermissionTestCaseMixin, APIBaseTestCase):
         self.app.refresh_from_db()
         self.assertEqual(self.app.config.get("renderPercentage"), 10)
 
+    @patch("marketplace.core.types.channels.weni_web_chat.serializers.FlowsClient")
+    @patch(
+        "marketplace.core.types.channels.weni_web_chat.serializers.AppStorage",
+        MockAppStorage,
+    )
+    def test_configure_with_position_bottom_left(self, mock_flows_client):
+        self.user_authorization = self.user.authorizations.create(
+            project_uuid=self.app.project_uuid
+        )
+        self.user_authorization.set_role(ProjectAuthorization.ROLE_ADMIN)
+
+        mock_flows_client.return_value.create_channel.return_value = {
+            "uuid": str(uuid.uuid4()),
+        }
+
+        self.body["config"]["position"] = "bottom-left"
+        response = self.request.patch(self.url, self.body, uuid=self.app.uuid)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.app.refresh_from_db()
+        self.assertEqual(self.app.config.get("position"), "bottom-left")
+
+    @patch("marketplace.core.types.channels.weni_web_chat.serializers.FlowsClient")
+    @patch(
+        "marketplace.core.types.channels.weni_web_chat.serializers.AppStorage",
+        MockAppStorage,
+    )
+    def test_configure_with_position_bottom_right(self, mock_flows_client):
+        self.user_authorization = self.user.authorizations.create(
+            project_uuid=self.app.project_uuid
+        )
+        self.user_authorization.set_role(ProjectAuthorization.ROLE_ADMIN)
+
+        mock_flows_client.return_value.create_channel.return_value = {
+            "uuid": str(uuid.uuid4()),
+        }
+
+        self.body["config"]["position"] = "bottom-right"
+        response = self.request.patch(self.url, self.body, uuid=self.app.uuid)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.app.refresh_from_db()
+        self.assertEqual(self.app.config.get("position"), "bottom-right")
+
+    @patch("marketplace.core.types.channels.weni_web_chat.serializers.FlowsClient")
+    @patch(
+        "marketplace.core.types.channels.weni_web_chat.serializers.AppStorage",
+        MockAppStorage,
+    )
+    def test_configure_without_position_defaults_to_bottom_right(
+        self, mock_flows_client
+    ):
+        self.user_authorization = self.user.authorizations.create(
+            project_uuid=self.app.project_uuid
+        )
+        self.user_authorization.set_role(ProjectAuthorization.ROLE_ADMIN)
+
+        mock_flows_client.return_value.create_channel.return_value = {
+            "uuid": str(uuid.uuid4()),
+        }
+
+        response = self.request.patch(self.url, self.body, uuid=self.app.uuid)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.app.refresh_from_db()
+        self.assertEqual(self.app.config.get("position"), "bottom-right")
+
+    @patch("marketplace.core.types.channels.weni_web_chat.serializers.FlowsClient")
+    @patch(
+        "marketplace.core.types.channels.weni_web_chat.serializers.AppStorage",
+        MockAppStorage,
+    )
+    def test_configure_with_empty_position_defaults_to_bottom_right(
+        self, mock_flows_client
+    ):
+        self.user_authorization = self.user.authorizations.create(
+            project_uuid=self.app.project_uuid
+        )
+        self.user_authorization.set_role(ProjectAuthorization.ROLE_ADMIN)
+
+        mock_flows_client.return_value.create_channel.return_value = {
+            "uuid": str(uuid.uuid4()),
+        }
+
+        self.body["config"]["position"] = ""
+        response = self.request.patch(self.url, self.body, uuid=self.app.uuid)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.app.refresh_from_db()
+        self.assertEqual(self.app.config.get("position"), "bottom-right")
+
+    def test_configure_with_invalid_position(self):
+        self.user_authorization = self.user.authorizations.create(
+            project_uuid=self.app.project_uuid
+        )
+        self.user_authorization.set_role(ProjectAuthorization.ROLE_ADMIN)
+
+        self.body["config"]["position"] = "top-left"
+        response = self.request.patch(self.url, self.body, uuid=self.app.uuid)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_configure_with_invalid_avatar(self):
         self.user_authorization = self.user.authorizations.create(
             project_uuid=self.app.project_uuid
@@ -697,9 +798,7 @@ class ConfigureWeniWebChatTestCase(PermissionTestCaseMixin, APIBaseTestCase):
                 self.assertEqual(self.app.config.get(field_name), field_value)
 
                 self.body["config"][field_name] = ""
-                response = self.request.patch(
-                    self.url, self.body, uuid=self.app.uuid
-                )
+                response = self.request.patch(self.url, self.body, uuid=self.app.uuid)
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
 
                 self.app.refresh_from_db()
@@ -893,6 +992,23 @@ class WeniWebChatVersionTestCase(PermissionTestCaseMixin, APIBaseTestCase):
 
         script_content = self._get_script_content()
         self.assertNotIn('"version"', script_content)
+
+    @patch("marketplace.core.types.channels.weni_web_chat.serializers.FlowsClient")
+    @patch(
+        "marketplace.core.types.channels.weni_web_chat.serializers.AppStorage",
+        CapturingMockAppStorage,
+    )
+    def test_configure_propagates_position_to_generated_script(self, mock_flows_client):
+        mock_flows_client.return_value.create_channel.return_value = {
+            "uuid": str(uuid.uuid4()),
+        }
+
+        self.body["config"]["position"] = "bottom-left"
+        response = self.request.patch(self.url, self.body, uuid=self.app.uuid)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        script_content = self._get_script_content()
+        self.assertIn('"position": "bottom-left"', script_content)
 
     @patch("marketplace.core.types.channels.weni_web_chat.serializers.FlowsClient")
     @patch(


### PR DESCRIPTION
## What

Adds support for a new `position` attribute in the Weni Web Chat (WWC)
apptype configuration, accepted via
`PATCH /api/v1/apptypes/wwc/apps/{app_uuid}/configure/`.

- New `WidgetPositionField` (a `ChoiceField` subclass) and the `position`
  field on `ConfigSerializer`, restricted to `bottom-right` / `bottom-left`,
  defaulting to `bottom-right`. An empty string falls back to the default so
  existing apps that send `""` are not rejected.
- The value is persisted on `app.config`, propagated into the generated
  widget script (`weni_p` passed to `WebChat.default.init`), and returned by
  the app's read endpoints (GET).
- Constants `WIDGET_POSITIONS` and `DEFAULT_WIDGET_POSITION` centralize the
  allowed values and default.

## Why

The onboarding backend (retail-setup) now sends a `position` attribute so the
webchat widget can be anchored to the bottom-right or bottom-left corner of
the page. The backend must accept, validate, persist and propagate this value
without breaking existing apps that don't send it.