### PR TITLE
feat: Add VTEX inline products upload endpoint with reusable test fakes

### DIFF
--- a/marketplace/core/types/ecommerce/dtos/upload_inline_products_dto.py
+++ b/marketplace/core/types/ecommerce/dtos/upload_inline_products_dto.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass(frozen=True)
+class UploadInlineProductsDTO:
+    """
+    Carries pre-formatted (and possibly edited) products to be uploaded to Meta.
+
+    The products follow the same shape returned by the inline sync endpoint, so each
+    item already holds Meta-ready fields and a unified `id` ("sku#seller").
+    """
+
+    products: List[Dict[str, str]]

--- a/marketplace/core/types/ecommerce/vtex/serializers.py
+++ b/marketplace/core/types/ecommerce/vtex/serializers.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
@@ -132,3 +134,54 @@ class FacebookProductDTOSerializer(serializers.Serializer):
     sale_price = serializers.CharField()
     additional_image_link = serializers.CharField(required=False)
     rich_text_description = serializers.CharField(required=False)
+
+
+class InlineProductItemSerializer(serializers.Serializer):
+    """
+    Validates a single pre-formatted product (inline shape) before uploading it to Meta.
+
+    The `id` is expected already unified as "sku#seller". Required fields mirror the Meta
+    business rules enforced by `ProductValidator`: they must be present and non-empty, and
+    `price` is required whenever the product is "in stock". Remaining optional fields default
+    to an empty string and are stripped from the payload downstream.
+    """
+
+    id = serializers.CharField()
+    title = serializers.CharField()
+    description = serializers.CharField()
+    availability = serializers.CharField()
+    status = serializers.CharField()
+    condition = serializers.CharField()
+    link = serializers.CharField()
+    image_link = serializers.CharField()
+    brand = serializers.CharField()
+    price = serializers.CharField(required=False, allow_blank=True, default="")
+    sale_price = serializers.CharField(required=False, allow_blank=True, default="")
+    additional_image_link = serializers.CharField(
+        required=False, allow_blank=True, default=""
+    )
+    rich_text_description = serializers.CharField(
+        required=False, allow_blank=True, default=""
+    )
+
+    def validate(self, attrs):
+        if attrs.get("availability") == "in stock" and not attrs.get("price"):
+            raise ValidationError(
+                {"price": "Price is required when availability is 'in stock'."}
+            )
+        return attrs
+
+
+class UploadInlineProductsSerializer(serializers.Serializer):
+    products = serializers.ListField(
+        child=InlineProductItemSerializer(),
+        allow_empty=False,
+    )
+
+    def validate_products(self, value):
+        max_batch = settings.VTEX_UPLOAD_PRODUCTS_MAX_BATCH
+        if len(value) > max_batch:
+            raise ValidationError(
+                f"A maximum of {max_batch} products can be uploaded per request."
+            )
+        return value

--- a/marketplace/core/types/ecommerce/vtex/tests/test_serializers.py
+++ b/marketplace/core/types/ecommerce/vtex/tests/test_serializers.py
@@ -1,0 +1,107 @@
+from django.test import TestCase, override_settings
+
+from marketplace.core.types.ecommerce.vtex.serializers import (
+    UploadInlineProductsSerializer,
+)
+
+
+def _build_product(**overrides):
+    product = {
+        "id": "1047#1",
+        "title": "Laranja Bahia Importada - Saco (15Kg)",
+        "description": "Laranja Bahia Importada - Saco (15Kg)",
+        "availability": "in stock",
+        "status": "active",
+        "condition": "new",
+        "price": "10.00 BRL",
+        "link": "https://www.arado.com.br/laranja-bahia-importada-1/p?idsku=1047",
+        "image_link": "https://arado.vteximg.com.br/arquivos/ids/158691/img.jpg",
+        "brand": "Arado",
+        "sale_price": "8.00 BRL",
+        "additional_image_link": "",
+        "rich_text_description": "",
+    }
+    product.update(overrides)
+    return product
+
+
+class UploadInlineProductsSerializerTest(TestCase):
+    def test_valid_payload(self):
+        serializer = UploadInlineProductsSerializer(
+            data={"products": [_build_product()]}
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertEqual(len(serializer.validated_data["products"]), 1)
+
+    def test_optional_fields_default_to_empty_string(self):
+        minimal_product = {
+            "id": "55#1",
+            "title": "Minimal",
+            "description": "desc",
+            "availability": "out of stock",
+            "status": "active",
+            "condition": "new",
+            "link": "https://example.com/p",
+            "image_link": "https://example.com/img.jpg",
+            "brand": "Arado",
+        }
+        serializer = UploadInlineProductsSerializer(
+            data={"products": [minimal_product]}
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+        product = serializer.validated_data["products"][0]
+        self.assertEqual(product["price"], "")
+        self.assertEqual(product["sale_price"], "")
+        self.assertEqual(product["additional_image_link"], "")
+        self.assertEqual(product["rich_text_description"], "")
+
+    def test_empty_products_list_is_invalid(self):
+        serializer = UploadInlineProductsSerializer(data={"products": []})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("products", serializer.errors)
+
+    def test_missing_required_field_is_invalid(self):
+        for field in (
+            "id",
+            "title",
+            "description",
+            "availability",
+            "status",
+            "condition",
+            "link",
+            "image_link",
+            "brand",
+        ):
+            product = _build_product()
+            product.pop(field)
+            serializer = UploadInlineProductsSerializer(data={"products": [product]})
+            self.assertFalse(
+                serializer.is_valid(),
+                f"Expected payload missing '{field}' to be invalid",
+            )
+            self.assertIn("products", serializer.errors)
+
+    def test_blank_required_field_is_invalid(self):
+        product = _build_product(brand="")
+        serializer = UploadInlineProductsSerializer(data={"products": [product]})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("products", serializer.errors)
+
+    def test_in_stock_without_price_is_invalid(self):
+        product = _build_product(availability="in stock", price="")
+        serializer = UploadInlineProductsSerializer(data={"products": [product]})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("products", serializer.errors)
+
+    def test_out_of_stock_without_price_is_valid(self):
+        product = _build_product(availability="out of stock", price="")
+        serializer = UploadInlineProductsSerializer(data={"products": [product]})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    @override_settings(VTEX_UPLOAD_PRODUCTS_MAX_BATCH=2)
+    def test_exceeding_max_batch_is_invalid(self):
+        products = [_build_product(id=f"{i}#1") for i in range(3)]
+        serializer = UploadInlineProductsSerializer(data={"products": products})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("products", serializer.errors)

--- a/marketplace/core/types/ecommerce/vtex/tests/test_usecases.py
+++ b/marketplace/core/types/ecommerce/vtex/tests/test_usecases.py
@@ -8,13 +8,22 @@ from unittest.mock import Mock, patch
 from rest_framework.exceptions import NotFound
 
 from marketplace.applications.models import App
-from marketplace.wpp_products.models import Catalog
+from marketplace.wpp_products.models import Catalog, UploadProduct
+from marketplace.core.types.ecommerce.dtos.upload_inline_products_dto import (
+    UploadInlineProductsDTO,
+)
 from marketplace.core.types.ecommerce.vtex.usecases.sync_on_demand import (
     SyncOnDemandUseCase,
+)
+from marketplace.core.types.ecommerce.vtex.usecases.upload_inline_products import (
+    UploadInlineProductsUseCase,
 )
 from marketplace.core.types.ecommerce.vtex.usecases.vtex_integration import (
     VtexIntegration,
 )
+from marketplace.services.vtex.tests.fakes import VtexTestEnvironment
+from marketplace.services.vtex.utils.enums import ProductPriority
+from marketplace.services.vtex.utils.facebook_product_dto import FacebookProductDTO
 
 
 User = get_user_model()
@@ -227,3 +236,211 @@ class SyncOnDemandUseCaseTest(TestCase):
 
         mock_filter.assert_called_once_with(sku_id="sku2", catalog="mock_catalog")
         self.assertFalse(result)
+
+
+UPLOAD_USECASE_PATH = (
+    "marketplace.core.types.ecommerce.vtex.usecases.upload_inline_products"
+)
+
+
+class UploadInlineProductsUseCaseTest(TestCase):
+    def setUp(self):
+        self.project_uuid = "project-uuid"
+        self.product = {
+            "id": "1047#1",
+            "title": "Laranja Bahia Importada - Saco (15Kg)",
+            "description": "Laranja Bahia Importada - Saco (15Kg)",
+            "availability": "in stock",
+            "status": "active",
+            "condition": "new",
+            "price": "10.00 BRL",
+            "link": "https://www.arado.com.br/laranja-bahia-importada-1/p?idsku=1047",
+            "image_link": "https://arado.vteximg.com.br/arquivos/ids/158691/img.jpg",
+            "brand": "Arado",
+            "sale_price": "8.00 BRL",
+            "additional_image_link": "",
+            "rich_text_description": "",
+        }
+        self.dto = UploadInlineProductsDTO(products=[self.product])
+
+        self.mock_product_manager = Mock()
+        self.use_case = UploadInlineProductsUseCase(
+            product_manager=self.mock_product_manager
+        )
+
+        self.mock_catalog = Mock(spec=Catalog)
+        self.mock_catalog.name = "Test Catalog"
+        self.mock_app = Mock(spec=App)
+        self.mock_app.uuid = "vtex-app-uuid"
+        self.mock_app.vtex_catalogs.first.return_value = self.mock_catalog
+
+    def test_default_priority_is_on_demand(self):
+        self.assertEqual(self.use_case.priority, ProductPriority.ON_DEMAND)
+
+    @patch(f"{UPLOAD_USECASE_PATH}.UploadManager.check_and_start_upload")
+    @patch("marketplace.applications.models.App.objects.get")
+    def test_execute_saves_products_and_triggers_upload(
+        self, mock_get, mock_check_upload
+    ):
+        mock_get.return_value = self.mock_app
+
+        total = self.use_case.execute(self.dto, self.project_uuid)
+
+        self.assertEqual(total, 1)
+        mock_get.assert_called_once_with(project_uuid=self.project_uuid, code="vtex")
+
+        self.mock_product_manager.bulk_save_initial_product_data.assert_called_once()
+        (
+            saved_products,
+            saved_catalog,
+        ) = self.mock_product_manager.bulk_save_initial_product_data.call_args.args
+        self.assertEqual(saved_catalog, self.mock_catalog)
+        self.assertEqual(len(saved_products), 1)
+        self.assertIsInstance(saved_products[0], FacebookProductDTO)
+        self.assertEqual(saved_products[0].id, "1047#1")
+
+        mock_check_upload.assert_called_once_with(
+            "vtex-app-uuid", priority=ProductPriority.ON_DEMAND
+        )
+
+    @patch(f"{UPLOAD_USECASE_PATH}.UploadManager.check_and_start_upload")
+    @patch("marketplace.applications.models.App.objects.get")
+    def test_execute_raises_not_found_when_vtex_app_missing(
+        self, mock_get, mock_check_upload
+    ):
+        mock_get.side_effect = App.DoesNotExist
+
+        with self.assertRaises(NotFound):
+            self.use_case.execute(self.dto, self.project_uuid)
+
+        self.mock_product_manager.bulk_save_initial_product_data.assert_not_called()
+        mock_check_upload.assert_not_called()
+
+    @patch(f"{UPLOAD_USECASE_PATH}.UploadManager.check_and_start_upload")
+    @patch("marketplace.applications.models.App.objects.get")
+    def test_execute_raises_not_found_when_no_catalog_linked(
+        self, mock_get, mock_check_upload
+    ):
+        self.mock_app.vtex_catalogs.first.return_value = None
+        mock_get.return_value = self.mock_app
+
+        with self.assertRaises(NotFound):
+            self.use_case.execute(self.dto, self.project_uuid)
+
+        self.mock_product_manager.bulk_save_initial_product_data.assert_not_called()
+        mock_check_upload.assert_not_called()
+
+    def test_build_product_dto_maps_all_fields(self):
+        dto = self.use_case._build_product_dto(self.product)
+
+        self.assertEqual(dto.id, "1047#1")
+        self.assertEqual(dto.title, self.product["title"])
+        self.assertEqual(dto.price, "10.00 BRL")
+        self.assertEqual(dto.sale_price, "8.00 BRL")
+        self.assertEqual(dto.product_details, {})
+
+    def test_build_product_dto_defaults_optional_fields(self):
+        minimal_product = {
+            "id": "55#1",
+            "title": "Minimal",
+            "availability": "in stock",
+            "status": "active",
+            "condition": "new",
+            "price": "1.00 BRL",
+            "link": "https://example.com/p",
+            "image_link": "https://example.com/img.jpg",
+        }
+
+        dto = self.use_case._build_product_dto(minimal_product)
+
+        self.assertEqual(dto.description, "")
+        self.assertEqual(dto.brand, "")
+        self.assertEqual(dto.sale_price, "")
+        self.assertEqual(dto.additional_image_link, "")
+        self.assertEqual(dto.rich_text_description, "")
+
+
+class UploadInlineProductsUseCaseIntegrationTest(TestCase):
+    """
+    Exercises the full use case against the real database, persisting UploadProduct rows.
+
+    Only the upload trigger (UploadManager -> redis/celery) is mocked, so the persistence
+    path (ProductFacebookManager, payload filtering and dedup) runs for real.
+    """
+
+    def setUp(self):
+        # Reuses the shared VTEX test environment (DB fixtures + fakes).
+        self.env = VtexTestEnvironment.create(catalog_name="Integration Catalog")
+        self.vtex_app = self.env.vtex_app
+        self.catalog = self.env.catalog
+        self.project_uuid = self.env.project_uuid
+
+        self.product = {
+            "id": "1047#1",
+            "title": "Laranja Bahia Importada - Saco (15Kg)",
+            "description": "Laranja Bahia Importada - Saco (15Kg)",
+            "availability": "in stock",
+            "status": "active",
+            "condition": "new",
+            "price": "10.00 BRL",
+            "link": "https://www.arado.com.br/laranja-bahia-importada-1/p?idsku=1047",
+            "image_link": "https://arado.vteximg.com.br/arquivos/ids/158691/img.jpg",
+            "brand": "Arado",
+            "sale_price": "8.00 BRL",
+            "additional_image_link": "",
+            "rich_text_description": "",
+        }
+        self.use_case = UploadInlineProductsUseCase()
+
+    @patch(f"{UPLOAD_USECASE_PATH}.UploadManager.check_and_start_upload")
+    def test_execute_persists_upload_products_and_triggers_upload(
+        self, mock_check_upload
+    ):
+        dto = UploadInlineProductsDTO(products=[self.product])
+
+        total = self.use_case.execute(dto, self.project_uuid)
+
+        self.assertEqual(total, 1)
+        mock_check_upload.assert_called_once_with(
+            str(self.vtex_app.uuid), priority=ProductPriority.ON_DEMAND
+        )
+
+        uploads = UploadProduct.objects.filter(catalog=self.catalog)
+        self.assertEqual(uploads.count(), 1)
+
+        upload = uploads.first()
+        self.assertEqual(upload.facebook_product_id, "1047#1")
+        self.assertEqual(upload.status, "pending")
+        self.assertEqual(upload.priority, ProductPriority.ON_DEMAND)
+        self.assertEqual(upload.data["id"], "1047#1")
+        self.assertEqual(upload.data["price"], "10.00 BRL")
+        self.assertEqual(upload.data["sale_price"], "8.00 BRL")
+        # Empty fields are stripped from the Meta payload
+        self.assertNotIn("additional_image_link", upload.data)
+        self.assertNotIn("rich_text_description", upload.data)
+
+    @patch(f"{UPLOAD_USECASE_PATH}.UploadManager.check_and_start_upload")
+    def test_execute_dedups_repeated_product_ids_keeping_latest(
+        self, mock_check_upload
+    ):
+        edited_product = dict(self.product, price="12.00 BRL")
+        dto = UploadInlineProductsDTO(products=[self.product, edited_product])
+
+        self.use_case.execute(dto, self.project_uuid)
+
+        uploads = UploadProduct.objects.filter(
+            catalog=self.catalog, facebook_product_id="1047#1"
+        )
+        self.assertEqual(uploads.count(), 1)
+        self.assertEqual(uploads.first().data["price"], "12.00 BRL")
+
+    @patch(f"{UPLOAD_USECASE_PATH}.UploadManager.check_and_start_upload")
+    def test_execute_raises_not_found_when_no_catalog_linked(self, mock_check_upload):
+        self.catalog.delete()
+        dto = UploadInlineProductsDTO(products=[self.product])
+
+        with self.assertRaises(NotFound):
+            self.use_case.execute(dto, self.project_uuid)
+
+        self.assertEqual(UploadProduct.objects.count(), 0)
+        mock_check_upload.assert_not_called()

--- a/marketplace/core/types/ecommerce/vtex/tests/test_views.py
+++ b/marketplace/core/types/ecommerce/vtex/tests/test_views.py
@@ -4,14 +4,19 @@ from unittest.mock import patch
 from unittest.mock import Mock
 from unittest.mock import PropertyMock
 
+from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from rest_framework import status
+from rest_framework.test import APIClient
 
 from marketplace.core.tests.base import APIBaseTestCase
 from marketplace.accounts.models import ProjectAuthorization
 from marketplace.applications.models import App
 from marketplace.core.tests.mixis.permissions import PermissionTestCaseMixin
+from marketplace.core.types.ecommerce.vtex.usecases.upload_inline_products import (
+    UploadInlineProductsUseCase,
+)
 from marketplace.core.types.ecommerce.vtex.views import (
     VtexIntegrationDetailsView,
     VtexViewSet,
@@ -483,16 +488,136 @@ class VtexIntegrationDetailsViewTest(APIBaseTestCase):
         return self.view_class.as_view()
 
 
-# TODO: Fix this test
-# class VtexSyncOnDemandViewE2ETest(APITestCase):
-#     @patch("marketplace.core.types.ecommerce.vtex.views.SyncOnDemandUseCase.execute")
-#     def test_post_sync_on_demand_success(self, mock_execute):
-#         url = reverse("sync-on-demand", args=[uuid.uuid4()])
+@override_settings(JWT_PUBLIC_KEY=b"fake-public-key")
+class VtexUploadInlineProductsViewTest(TestCase):
+    """E2E tests for the inline products upload endpoint (JWT auth boundary)."""
 
-#         payload = {"seller": "seller1", "sku_ids": ["sku1", "sku2"]}
+    def setUp(self):
+        self.client = APIClient()
+        self.url = reverse("upload-inline-products")
+        self.project_uuid = str(uuid.uuid4())
+        self.auth_header = {"HTTP_AUTHORIZATION": "Bearer fake-token"}
+        self.payload = {
+            "products": [
+                {
+                    "id": "1047#1",
+                    "title": "Laranja Bahia Importada - Saco (15Kg)",
+                    "description": "Laranja Bahia Importada - Saco (15Kg)",
+                    "availability": "in stock",
+                    "status": "active",
+                    "condition": "new",
+                    "price": "10.00 BRL",
+                    "link": "https://www.arado.com.br/p?idsku=1047",
+                    "image_link": "https://arado.vteximg.com.br/arquivos/img.jpg",
+                    "brand": "Arado",
+                    "sale_price": "8.00 BRL",
+                }
+            ]
+        }
 
-#         response = self.client.post(url, payload, format="json")
+    @patch("marketplace.internal.jwt_authenticators.jwt.decode")
+    @patch.object(UploadInlineProductsUseCase, "execute")
+    def test_post_success_returns_202(self, mock_execute, mock_decode):
+        mock_decode.return_value = {"project_uuid": self.project_uuid}
+        mock_execute.return_value = 1
 
-#         self.assertEqual(response.status_code, status.HTTP_200_OK)
-#         self.assertEqual(response.data, {"message": "Products sent to sync."})
-#         mock_execute.assert_called_once()
+        response = self.client.post(
+            self.url, self.payload, format="json", **self.auth_header
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.assertEqual(response.json()["total_products"], 1)
+
+        called_dto, called_project = mock_execute.call_args.args
+        self.assertEqual(called_project, self.project_uuid)
+        self.assertEqual(len(called_dto.products), 1)
+        self.assertEqual(called_dto.products[0]["id"], "1047#1")
+
+    @patch("marketplace.internal.jwt_authenticators.jwt.decode")
+    @patch.object(UploadInlineProductsUseCase, "execute")
+    def test_post_empty_products_returns_400(self, mock_execute, mock_decode):
+        mock_decode.return_value = {"project_uuid": self.project_uuid}
+
+        response = self.client.post(
+            self.url, {"products": []}, format="json", **self.auth_header
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        mock_execute.assert_not_called()
+
+    @patch("marketplace.internal.jwt_authenticators.jwt.decode")
+    @patch.object(UploadInlineProductsUseCase, "execute")
+    def test_post_in_stock_without_price_returns_400(self, mock_execute, mock_decode):
+        mock_decode.return_value = {"project_uuid": self.project_uuid}
+        payload = {"products": [dict(self.payload["products"][0], price="")]}
+
+        response = self.client.post(
+            self.url, payload, format="json", **self.auth_header
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        mock_execute.assert_not_called()
+
+    def test_post_without_authentication_is_rejected(self):
+        response = self.client.post(self.url, self.payload, format="json")
+
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )
+
+
+@override_settings(JWT_PUBLIC_KEY=b"fake-public-key")
+class VtexSyncOnDemandViewTest(TestCase):
+    """E2E tests for the async on-demand sync endpoint (JWT auth boundary)."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.url = reverse("sync-on-demand")
+        self.project_uuid = str(uuid.uuid4())
+        self.auth_header = {"HTTP_AUTHORIZATION": "Bearer fake-token"}
+        self.payload = {
+            "seller": "1",
+            "sku_ids": ["123", "456"],
+            "sales_channel": ["1"],
+        }
+
+    @patch(
+        "marketplace.core.types.ecommerce.vtex.views.task_sync_on_demand.apply_async"
+    )
+    @patch("marketplace.internal.jwt_authenticators.jwt.decode")
+    def test_post_success_dispatches_task(self, mock_decode, mock_apply_async):
+        mock_decode.return_value = {"project_uuid": self.project_uuid}
+
+        response = self.client.post(
+            self.url, self.payload, format="json", **self.auth_header
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["message"], "Products sent to sync on demand.")
+        mock_apply_async.assert_called_once_with(
+            args=[self.project_uuid, ["123", "456"], "1", ["1"]],
+            queue="vtex-sync-on-demand",
+        )
+
+    @patch(
+        "marketplace.core.types.ecommerce.vtex.views.task_sync_on_demand.apply_async"
+    )
+    @patch("marketplace.internal.jwt_authenticators.jwt.decode")
+    def test_post_without_sku_ids_returns_400(self, mock_decode, mock_apply_async):
+        mock_decode.return_value = {"project_uuid": self.project_uuid}
+
+        response = self.client.post(
+            self.url, {"seller": "1"}, format="json", **self.auth_header
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        mock_apply_async.assert_not_called()
+
+    def test_post_without_authentication_is_rejected(self):
+        response = self.client.post(self.url, self.payload, format="json")
+
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )

--- a/marketplace/core/types/ecommerce/vtex/urls.py
+++ b/marketplace/core/types/ecommerce/vtex/urls.py
@@ -4,6 +4,7 @@ from .views import (
     VtexIntegrationDetailsView,
     VtexSyncOnDemandInlineView,
     VtexSyncOnDemandView,
+    VtexUploadInlineProductsView,
 )
 
 
@@ -22,5 +23,10 @@ urlpatterns = [
         "sync-on-demand-inline/",
         VtexSyncOnDemandInlineView.as_view(),
         name="sync-on-demand-inline",
+    ),
+    path(
+        "upload-inline-products/",
+        VtexUploadInlineProductsView.as_view(),
+        name="upload-inline-products",
     ),
 ]

--- a/marketplace/core/types/ecommerce/vtex/usecases/upload_inline_products.py
+++ b/marketplace/core/types/ecommerce/vtex/usecases/upload_inline_products.py
@@ -1,0 +1,90 @@
+import logging
+
+from typing import Optional
+
+from rest_framework.exceptions import NotFound
+
+from marketplace.applications.models import App
+from marketplace.core.types.ecommerce.dtos.upload_inline_products_dto import (
+    UploadInlineProductsDTO,
+)
+from marketplace.services.product.product_facebook_manage import ProductFacebookManager
+from marketplace.services.vtex.utils.enums import ProductPriority
+from marketplace.services.vtex.utils.facebook_product_dto import FacebookProductDTO
+from marketplace.wpp_products.utils import UploadManager
+
+
+logger = logging.getLogger(__name__)
+
+
+class UploadInlineProductsUseCase:
+    """
+    Persists pre-formatted inline products and triggers their upload to Meta.
+
+    Unlike the inline sync flow, products arrive already formatted by the caller (optionally
+    edited), so no VTEX lookup is performed. Credentials and catalog resolution mirror the
+    inline flow: the VTEX app is resolved from the project UUID carried by the JWT and its
+    linked catalog drives the Meta upload (using the wpp-cloud system token under the hood).
+    """
+
+    def __init__(
+        self,
+        product_manager: Optional[ProductFacebookManager] = None,
+        priority: int = ProductPriority.ON_DEMAND,
+    ) -> None:
+        self.priority = priority
+        self.product_manager = product_manager or ProductFacebookManager(
+            priority=priority
+        )
+
+    def execute(self, dto: UploadInlineProductsDTO, project_uuid: str) -> int:
+        """
+        Save the products and dispatch the asynchronous upload.
+
+        Returns:
+            The number of products queued for upload.
+        """
+        vtex_app = self._get_vtex_app(project_uuid)
+        catalog = vtex_app.vtex_catalogs.first()
+        if not catalog:
+            raise NotFound(
+                "No catalog is linked to the VTEX app for the provided project UUID."
+            )
+
+        products_dto = [self._build_product_dto(product) for product in dto.products]
+
+        logger.info(
+            f"Uploading {len(products_dto)} inline products for "
+            f"project={project_uuid} catalog={catalog.name}"
+        )
+        self.product_manager.bulk_save_initial_product_data(products_dto, catalog)
+        UploadManager.check_and_start_upload(str(vtex_app.uuid), priority=self.priority)
+
+        return len(products_dto)
+
+    def _get_vtex_app(self, project_uuid: str) -> App:
+        try:
+            return App.objects.get(project_uuid=project_uuid, code="vtex")
+        except App.DoesNotExist:
+            raise NotFound(
+                "A vtex-app integration was not found for the provided project UUID."
+            )
+
+    @staticmethod
+    def _build_product_dto(product: dict) -> FacebookProductDTO:
+        return FacebookProductDTO(
+            id=product["id"],
+            title=product["title"],
+            description=product.get("description", ""),
+            availability=product["availability"],
+            status=product["status"],
+            condition=product["condition"],
+            price=product.get("price", ""),
+            link=product["link"],
+            image_link=product["image_link"],
+            brand=product.get("brand", ""),
+            sale_price=product.get("sale_price", ""),
+            additional_image_link=product.get("additional_image_link", ""),
+            rich_text_description=product.get("rich_text_description", ""),
+            product_details={},
+        )

--- a/marketplace/core/types/ecommerce/vtex/views.py
+++ b/marketplace/core/types/ecommerce/vtex/views.py
@@ -6,9 +6,13 @@ from rest_framework.decorators import action
 from rest_framework.views import APIView
 
 from marketplace.core.types.ecommerce.dtos.sync_on_demand_dto import SyncOnDemandDTO
+from marketplace.core.types.ecommerce.dtos.upload_inline_products_dto import (
+    UploadInlineProductsDTO,
+)
 from marketplace.core.types.ecommerce.vtex.serializers import (
     FacebookProductDTOSerializer,
     FirstProductInsertSerializer,
+    UploadInlineProductsSerializer,
     VtexAdsSerializer,
     VtexIOSerializer,
     VtexSerializer,
@@ -23,6 +27,9 @@ from marketplace.core.types.ecommerce.vtex.usecases.link_catalog_start_sync impo
 )
 from marketplace.core.types.ecommerce.vtex.usecases.sync_on_demand_in_line import (
     SyncOnDemandInlineUseCase,
+)
+from marketplace.core.types.ecommerce.vtex.usecases.upload_inline_products import (
+    UploadInlineProductsUseCase,
 )
 from marketplace.core.types.ecommerce.vtex.usecases.vtex_integration import (
     VtexIntegration,
@@ -261,7 +268,7 @@ class VtexIntegrationDetailsView(APIView):
         return Response(status=status.HTTP_200_OK, data=integration_details)
 
 
-class VtexSyncOnDemandView(JWTModuleAuthMixin, APIView):  # pragma: no cover
+class VtexSyncOnDemandView(JWTModuleAuthMixin, APIView):
     def post(self, request, *args, **kwargs) -> Response:
         serializer = SyncOnDemandSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -354,4 +361,58 @@ class VtexSyncOnDemandInlineView(JWTModuleAuthMixin, APIView):  # pragma: no cov
                 "invalid_skus": invalid_skus,
             },
             status=status.HTTP_200_OK,
+        )
+
+
+class VtexUploadInlineProductsView(JWTModuleAuthMixin, APIView):
+    """
+    Uploads a list of pre-formatted (optionally edited) inline products to Meta.
+
+    Reuses the inline endpoint credentials: the VTEX app is resolved from the JWT
+    project_uuid and its linked catalog drives the Meta upload. Products are expected in the
+    same shape returned by the inline endpoint (with `id` already unified as "sku#seller").
+    They are persisted with on-demand priority and uploaded asynchronously to Meta.
+
+    Example request:
+        {
+            "products": [
+                {
+                    "id": "1047#1",
+                    "title": "Laranja Bahia Importada - Saco (15Kg)",
+                    "description": "Laranja Bahia Importada - Saco (15Kg)",
+                    "availability": "in stock",
+                    "status": "active",
+                    "condition": "new",
+                    "price": "10.00 BRL",
+                    "link": "https://www.site.com.br/laranja-bahia-importada-1/p?idsku=1047",
+                    "image_link": "https://site.vteximg.com.br/arquivos/ids/158691/868140a9.jpg",
+                    "brand": "Arado",
+                    "sale_price": "8.00 BRL",
+                    "additional_image_link": "",
+                    "rich_text_description": ""
+                }
+            ]
+        }
+
+    Example response:
+        {
+            "message": "Products queued for upload to Meta.",
+            "total_products": 1
+        }
+    """
+
+    def post(self, request, *args, **kwargs) -> Response:
+        serializer = UploadInlineProductsSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        dto = UploadInlineProductsDTO(products=serializer.validated_data["products"])
+        use_case = UploadInlineProductsUseCase()
+        total_products = use_case.execute(dto, self.project_uuid)
+
+        return Response(
+            {
+                "message": "Products queued for upload to Meta.",
+                "total_products": total_products,
+            },
+            status=status.HTTP_202_ACCEPTED,
         )

--- a/marketplace/services/vtex/tests/fakes/README.md
+++ b/marketplace/services/vtex/tests/fakes/README.md
@@ -1,0 +1,132 @@
+# VTEX test fakes
+
+Reusable **test doubles (Fakes)** for VTEX and Meta (Facebook) integrations.
+
+A *Fake* is a lightweight, working in-memory implementation that honors the same
+contract as the real collaborator (like an in-memory database). Inject these
+wherever a real client/service is expected to exercise catalog **sync** and
+**upload** flows **without performing any external HTTP call** (VTEX, Meta),
+**Redis** or **broker**.
+
+> Prefer this toolkit over ad-hoc `Mock()`/`patch` when writing tests for VTEX
+> catalog, products, sync or upload flows.
+
+## Components
+
+| Symbol | Purpose |
+|---|---|
+| `FakeVtexClient` | In-memory client with the full `VtexPrivateClient`/`VtexProxyClient` contract (sellers, SKU ids, product details, cart simulation). Builder API + call spy. |
+| `FakeFacebookCatalogClient` | In-memory Meta catalog client (`items_batch` + catalog lifecycle). Records uploaded batches/items. |
+| `VtexTestEnvironment` | Creates the DB fixtures (vtex `App` + wpp-cloud `App` + linked `Catalog`) and wires a `FakeVtexClient` + real `PrivateProductsService`. |
+| `VtexFakeTestCase` | Base `TestCase` with isolated `LocMemCache` and a ready-to-use `self.vtex` environment. |
+| `build_sku_detail` / `build_order_form_simulation` / `normalize_simulation_item` | Builders for the raw VTEX payload shapes. |
+
+All symbols are importable from the package root:
+
+```python
+from marketplace.services.vtex.tests.fakes import (
+    FakeVtexClient,
+    FakeFacebookCatalogClient,
+    VtexTestEnvironment,
+    VtexFakeTestCase,
+    build_sku_detail,
+)
+```
+
+## Quickstart
+
+### 1. Base test case (recommended)
+
+Subclass `VtexFakeTestCase` and declare your scenario in `build_environment`:
+
+```python
+from marketplace.services.vtex.tests.fakes import VtexFakeTestCase, VtexTestEnvironment
+
+
+class MyCatalogFlowTest(VtexFakeTestCase):
+    def build_environment(self) -> VtexTestEnvironment:
+        return (
+            VtexTestEnvironment.create(store_domain="www.mystore.com.br")
+            .add_product("1047", price=1500, selling_price=1200, brand="Arado")
+            .add_product("2099", available=False)
+        )
+
+    def test_fetches_product(self):
+        details = self.vtex.service.get_product_details("1047", self.vtex.domain)
+        self.assertEqual(details["Id"], "1047")
+        # self.vtex.catalog / self.vtex.vtex_app / self.vtex.project_uuid available too
+```
+
+### 2. Standalone client (no DB needed)
+
+```python
+from marketplace.services.vtex.private.products.service import PrivateProductsService
+from marketplace.services.vtex.tests.fakes import FakeVtexClient
+
+client = FakeVtexClient().add_product("1047", sellers=["1"], price=1500)
+service = PrivateProductsService(client)
+
+# unknown SKU -> raises CustomAPIException(status_code=404)
+# .calls records every contract call for spy-style assertions
+```
+
+### 3. Full pipeline through the real `DataProcessor`
+
+Run the production extraction/validation pipeline against in-memory data
+(`API_ONLY` returns DTOs without writing to the DB):
+
+```python
+from marketplace.services.vtex.utils.data_processor import DataProcessor
+from marketplace.services.vtex.utils.enums import ProductPriority
+
+results = DataProcessor(use_threads=False).process(
+    items=["1047"],
+    catalog=self.vtex.catalog,
+    domain=self.vtex.domain,
+    service=self.vtex.service,
+    rules=[],
+    store_domain=self.vtex.store_domain,
+    mode="single",
+    sellers=["1"],
+    priority=ProductPriority.API_ONLY,
+)
+# results[0] is a faithful FacebookProductDTO
+```
+
+> The pipeline's `SKUValidator` touches Redis/cache. Under `VtexFakeTestCase`
+> the cache is already a `LocMemCache`; patch the redis connection and
+> `close_old_connections` for the few code paths that use them:
+> ```python
+> @patch("marketplace.services.vtex.utils.data_processor.close_old_connections")
+> @patch("marketplace.services.vtex.utils.sku_validator.get_redis_connection", return_value=MagicMock())
+> ```
+
+### 4. Upload to Meta (Facebook)
+
+```python
+from marketplace.services.facebook.service import FacebookService
+from marketplace.services.vtex.tests.fakes import FakeFacebookCatalogClient
+
+fb = FakeFacebookCatalogClient()
+FacebookService(fb).upload_batch("catalog-123", payload)
+
+assert fb.uploaded_items          # flattened item `data` dicts
+assert fb.calls[0][0] == "upload_items_batch"
+```
+
+To exercise the real upload task (`ProductBatchUploader`), swap the client class:
+
+```python
+from marketplace.wpp_products.utils import ProductBatchUploader
+
+ProductBatchUploader.fb_client_class = FakeFacebookCatalogClient  # patch in the test
+```
+
+## Conventions & notes
+
+- **Prices** follow the VTEX convention of **integer cents** (e.g. `1500` == 15.00).
+- This package lives under `tests/` and is **omitted from coverage** by design.
+- Keep the fakes **faithful**: when a real response shape changes, update the
+  builders in `payloads.py` so every dependent test stays realistic.
+- Extend the fakes by adding methods that mirror the real client contract and
+  recording calls in `self.calls`; avoid adding behavior the real client lacks.

--- a/marketplace/services/vtex/tests/fakes/__init__.py
+++ b/marketplace/services/vtex/tests/fakes/__init__.py
@@ -1,0 +1,30 @@
+"""
+Reusable test doubles (Fakes) for VTEX integrations.
+
+A Fake is a working in-memory implementation that honors the same contract as the
+real collaborator (akin to an in-memory database). Inject `FakeVtexClient` wherever
+a VTEX client is expected to exercise catalog sync/upload flows without hitting VTEX.
+"""
+
+from marketplace.services.vtex.tests.fakes.base import VtexFakeTestCase
+from marketplace.services.vtex.tests.fakes.environment import VtexTestEnvironment
+from marketplace.services.vtex.tests.fakes.facebook_client import (
+    FakeFacebookCatalogClient,
+)
+from marketplace.services.vtex.tests.fakes.payloads import (
+    build_order_form_simulation,
+    build_sku_detail,
+    normalize_simulation_item,
+)
+from marketplace.services.vtex.tests.fakes.vtex_client import FakeVtexClient
+
+
+__all__ = [
+    "FakeVtexClient",
+    "FakeFacebookCatalogClient",
+    "VtexTestEnvironment",
+    "VtexFakeTestCase",
+    "build_sku_detail",
+    "build_order_form_simulation",
+    "normalize_simulation_item",
+]

--- a/marketplace/services/vtex/tests/fakes/base.py
+++ b/marketplace/services/vtex/tests/fakes/base.py
@@ -1,0 +1,43 @@
+"""
+Base TestCase for VTEX flows backed by in-memory fakes.
+
+Provides an isolated LocMemCache (so tests never hit Redis) and a ready-to-use
+`self.vtex` environment. Subclasses can override `build_environment` to customize
+the fixtures.
+
+Example:
+    class MyUploadFlowTest(VtexFakeTestCase):
+        def build_environment(self):
+            return VtexTestEnvironment.create().add_product("1047", price=1500)
+
+        def test_something(self):
+            details = self.vtex.service.get_product_details("1047", self.vtex.domain)
+            ...
+"""
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from marketplace.services.vtex.tests.fakes.environment import VtexTestEnvironment
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "vtex-fake-testcase",
+        }
+    }
+)
+class VtexFakeTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+        self.vtex = self.build_environment()
+
+    def tearDown(self):
+        cache.clear()
+        super().tearDown()
+
+    def build_environment(self) -> VtexTestEnvironment:
+        return VtexTestEnvironment.create()

--- a/marketplace/services/vtex/tests/fakes/environment.py
+++ b/marketplace/services/vtex/tests/fakes/environment.py
@@ -1,0 +1,116 @@
+"""
+Reusable in-memory VTEX environment for tests.
+
+`VtexTestEnvironment` bundles the database fixtures (vtex App, wpp-cloud App and a
+linked Catalog) with a `FakeVtexClient` and a real `PrivateProductsService`, so
+catalog sync/upload flows can be exercised end-to-end without touching VTEX/Meta.
+
+Example:
+    env = VtexTestEnvironment.create().add_product("1047", price=1500)
+    details = env.service.get_product_details("1047", env.domain)
+"""
+
+import uuid as uuid_lib
+
+from dataclasses import dataclass
+from typing import Optional
+
+from django.contrib.auth import get_user_model
+
+from marketplace.applications.models import App
+from marketplace.services.vtex.private.products.service import PrivateProductsService
+from marketplace.services.vtex.tests.fakes.vtex_client import FakeVtexClient
+from marketplace.wpp_products.models import Catalog
+
+
+User = get_user_model()
+
+
+@dataclass
+class VtexTestEnvironment:
+    user: object
+    vtex_app: App
+    wpp_cloud_app: App
+    catalog: Catalog
+    client: FakeVtexClient
+    service: PrivateProductsService
+    store_domain: str
+    domain: str
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        project_uuid: Optional[str] = None,
+        store_domain: str = "store.myvtex.com",
+        domain: Optional[str] = None,
+        facebook_catalog_id: str = "123456789",
+        catalog_name: str = "Fake Catalog",
+        domain_valid: bool = True,
+        credentials_valid: bool = True,
+        config: Optional[dict] = None,
+    ) -> "VtexTestEnvironment":
+        """Create the DB fixtures and wire the fakes into a ready-to-use environment."""
+        project_uuid = project_uuid or str(uuid_lib.uuid4())
+        domain = domain or store_domain
+
+        user = User.objects.create_user(
+            email=f"vtex-fake-{uuid_lib.uuid4().hex[:8]}@marketplace.ai",
+            password="fake@pass#$",
+        )
+        vtex_config = config or {
+            "api_credentials": {
+                "app_key": "fake-key",
+                "app_token": "fake-token",
+                "domain": domain,
+            },
+            "initial_sync_completed": True,
+            "connected_catalog": True,
+        }
+        vtex_app = App.objects.create(
+            code="vtex",
+            created_by=user,
+            project_uuid=project_uuid,
+            platform=App.PLATFORM_VTEX,
+            config=vtex_config,
+        )
+        wpp_cloud_app = App.objects.create(
+            code="wpp-cloud",
+            created_by=user,
+            project_uuid=project_uuid,
+            platform=App.PLATFORM_WENI_FLOWS,
+        )
+        catalog = Catalog.objects.create(
+            app=wpp_cloud_app,
+            vtex_app=vtex_app,
+            facebook_catalog_id=facebook_catalog_id,
+            name=catalog_name,
+            created_by=user,
+        )
+        client = FakeVtexClient(
+            domain_valid=domain_valid, credentials_valid=credentials_valid
+        )
+        service = PrivateProductsService(client)
+
+        return cls(
+            user=user,
+            vtex_app=vtex_app,
+            wpp_cloud_app=wpp_cloud_app,
+            catalog=catalog,
+            client=client,
+            service=service,
+            store_domain=store_domain,
+            domain=domain,
+        )
+
+    @property
+    def project_uuid(self) -> str:
+        return str(self.vtex_app.project_uuid)
+
+    def add_product(self, sku_id, **kwargs) -> "VtexTestEnvironment":
+        self.client.add_product(sku_id, **kwargs)
+        return self
+
+    def add_seller(self, seller_id, **kwargs) -> "VtexTestEnvironment":
+        self.client.add_seller(seller_id, **kwargs)
+        return self

--- a/marketplace/services/vtex/tests/fakes/facebook_client.py
+++ b/marketplace/services/vtex/tests/fakes/facebook_client.py
@@ -1,0 +1,70 @@
+"""
+In-memory Fake for the Meta (Facebook) Catalog client.
+
+`FakeFacebookCatalogClient` implements the catalog/upload surface used by the
+product upload flow, recording uploaded batches and returning realistic
+responses. Use it to test upload-to-Meta flows without performing real HTTP calls.
+
+Wiring into the upload pipeline:
+    from marketplace.wpp_products.utils import ProductBatchUploader
+    ProductBatchUploader.fb_client_class = FakeFacebookCatalogClient
+
+or, at the service level:
+    FacebookService(FakeFacebookCatalogClient())
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+
+class FakeFacebookCatalogClient:
+    def __init__(self, access_token: Optional[str] = None) -> None:
+        self.access_token = access_token
+        self.uploaded_batches: List[Dict[str, Any]] = []
+        # Spy: records every call as (method_name, kwargs).
+        self.calls: List[Tuple[str, dict]] = []
+
+    def _record(self, method: str, **kwargs) -> None:
+        self.calls.append((method, kwargs))
+
+    def upload_items_batch(self, catalog_id, payload) -> Dict[str, Any]:
+        """Mirror Meta `/{catalog_id}/items_batch`, returning handles on success."""
+        self._record("upload_items_batch", catalog_id=catalog_id, payload=payload)
+        self.uploaded_batches.append({"catalog_id": catalog_id, "payload": payload})
+        requests = payload.get("requests", [])
+        return {
+            "handles": [
+                f"handle-{catalog_id}-{index}" for index in range(len(requests))
+            ]
+        }
+
+    @property
+    def uploaded_items(self) -> List[Dict[str, Any]]:
+        """Flatten the item `data` dicts across every uploaded batch."""
+        items: List[Dict[str, Any]] = []
+        for batch in self.uploaded_batches:
+            for request in batch["payload"].get("requests", []):
+                items.append(request.get("data", {}))
+        return items
+
+    # ================================
+    # Catalog lifecycle (minimal; extend as flows require)
+    # ================================
+    def create_catalog(self, business_id, name) -> Dict[str, Any]:
+        self._record("create_catalog", business_id=business_id, name=name)
+        return {"id": "fake-catalog-id"}
+
+    def destroy_catalog(self, catalog_id) -> bool:
+        self._record("destroy_catalog", catalog_id=catalog_id)
+        return True
+
+    def enable_catalog(self, waba_id, catalog_id) -> Dict[str, Any]:
+        self._record("enable_catalog", waba_id=waba_id, catalog_id=catalog_id)
+        return {"success": True}
+
+    def disable_catalog(self, waba_id, catalog_id) -> Dict[str, Any]:
+        self._record("disable_catalog", waba_id=waba_id, catalog_id=catalog_id)
+        return {"success": True}
+
+    def get_connected_catalog(self, waba_id) -> Dict[str, Any]:
+        self._record("get_connected_catalog", waba_id=waba_id)
+        return {"data": []}

--- a/marketplace/services/vtex/tests/fakes/payloads.py
+++ b/marketplace/services/vtex/tests/fakes/payloads.py
@@ -1,0 +1,99 @@
+"""
+Faithful builders for raw VTEX API payloads used by test doubles.
+
+These helpers mirror the JSON shapes returned by the real VTEX endpoints so fakes
+and tests exercise the same parsing/normalization the production clients rely on.
+"""
+
+from typing import Any, Dict, List
+
+
+def build_sku_detail(
+    sku_id,
+    *,
+    product_id=None,
+    name=None,
+    product_name=None,
+    description=None,
+    brand="Arado",
+    is_active=True,
+    image_url=None,
+    detail_url=None,
+    sellers=None,
+) -> Dict[str, Any]:
+    """
+    Build a payload shaped like VTEX `.../pvt/sku/stockkeepingunitbyid/{sku_id}`.
+
+    Only the fields consumed by the product pipeline (ProductExtractor and
+    SKUValidator) are guaranteed; the structure follows the real response.
+    """
+    sku_id = str(sku_id)
+    product_id = str(product_id or sku_id)
+    name = name or f"Product {sku_id}"
+    sellers = [str(seller) for seller in (sellers or ["1"])]
+
+    return {
+        "Id": sku_id,
+        "ProductId": product_id,
+        "NameComplete": name,
+        "ProductName": product_name or name,
+        "ProductDescription": description if description is not None else name,
+        "SkuName": name,
+        "IsActive": is_active,
+        "BrandId": "2000000",
+        "BrandName": brand,
+        "DetailUrl": detail_url or f"/{sku_id}/p",
+        "Images": [
+            {
+                "ImageUrl": image_url or f"https://images.vtex.com/ids/{sku_id}.jpg",
+                "IsMain": True,
+            }
+        ],
+        "SkuSellers": [
+            {"SellerId": seller, "StockKeepingUnitId": sku_id} for seller in sellers
+        ],
+    }
+
+
+def build_order_form_simulation(items: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Build a payload shaped like VTEX `/api/checkout/pub/orderForms/simulation`.
+
+    Prices follow the VTEX convention of integer cents (e.g. 10000 == 100.00).
+    Each input item accepts: id, seller, available (bool), price, list_price,
+    selling_price, quantity.
+    """
+    order_items = []
+    for item in items:
+        price = item.get("price", 10000)
+        order_items.append(
+            {
+                "id": str(item["id"]),
+                "seller": str(item["seller"]),
+                "quantity": item.get("quantity", 1),
+                "availability": (
+                    "available" if item.get("available", True) else "cannotBeDelivered"
+                ),
+                "price": price,
+                "listPrice": item.get("list_price", price),
+                "sellingPrice": item.get("selling_price", price),
+            }
+        )
+    return {"items": order_items}
+
+
+def normalize_simulation_item(
+    item: Dict[str, Any], full_response: Dict[str, Any]
+) -> Dict[str, Any]:
+    """
+    Normalize a raw VTEX simulation item to the shape returned by the VTEX clients.
+
+    Mirrors the transformation performed by `VtexPrivateClient`/`VtexProxyClient`.
+    """
+    return {
+        "is_available": item.get("availability") == "available",
+        "price": item.get("price", 0),
+        "list_price": item.get("listPrice", 0),
+        "selling_price": item.get("sellingPrice", 0),
+        "data": full_response,
+    }

--- a/marketplace/services/vtex/tests/fakes/vtex_client.py
+++ b/marketplace/services/vtex/tests/fakes/vtex_client.py
@@ -1,0 +1,174 @@
+"""
+In-memory Fake of the VTEX client.
+
+`FakeVtexClient` implements the same surface as `VtexPrivateClient`/`VtexProxyClient`,
+backed by an in-memory dataset of VTEX-shaped payloads. Inject it wherever a VTEX
+client is expected (e.g. `PrivateProductsService(FakeVtexClient(...))`) to exercise
+catalog sync/upload flows without performing real HTTP calls.
+
+Example:
+    client = (
+        FakeVtexClient()
+        .add_product("1047", sellers=["1"], available=True, price=1500)
+        .add_product("2099", sellers=["1", "2"], available=False)
+    )
+    service = PrivateProductsService(client)
+    details = service.get_product_details("1047", "store.myvtex.com")
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from marketplace.clients.exceptions import CustomAPIException
+from marketplace.services.vtex.tests.fakes.payloads import (
+    build_order_form_simulation,
+    build_sku_detail,
+    normalize_simulation_item,
+)
+
+
+class FakeVtexClient:
+    def __init__(
+        self, *, domain_valid: bool = True, credentials_valid: bool = True
+    ) -> None:
+        self.domain_valid = domain_valid
+        self.credentials_valid = credentials_valid
+        self._sellers: List[str] = []
+        self._details: Dict[str, dict] = {}
+        self._specs: Dict[str, Any] = {}
+        self._items: Dict[Tuple[str, str, Optional[str]], dict] = {}
+        # Spy: records every contract call as (method_name, kwargs).
+        self.calls: List[Tuple[str, dict]] = []
+
+    # ================================
+    # Dataset registration (builder API)
+    # ================================
+    def add_seller(self, seller_id, *, active: bool = True) -> "FakeVtexClient":
+        seller_id = str(seller_id)
+        if active and seller_id not in self._sellers:
+            self._sellers.append(seller_id)
+        return self
+
+    def add_product(
+        self,
+        sku_id,
+        *,
+        sellers: Optional[List[str]] = None,
+        available: bool = True,
+        price: int = 10000,
+        list_price: Optional[int] = None,
+        selling_price: Optional[int] = None,
+        sales_channel: Optional[str] = None,
+        specification: Any = None,
+        **detail_overrides,
+    ) -> "FakeVtexClient":
+        """Register a product (SKU detail + per-seller cart availability)."""
+        sku_id = str(sku_id)
+        sellers = [str(seller) for seller in (sellers or ["1"])]
+        self._details[sku_id] = build_sku_detail(
+            sku_id, sellers=sellers, **detail_overrides
+        )
+        if specification is not None:
+            self._specs[self._details[sku_id]["ProductId"]] = specification
+
+        channel = str(sales_channel) if sales_channel is not None else None
+        for seller in sellers:
+            self.add_seller(seller)
+            self._items[(sku_id, seller, channel)] = {
+                "id": sku_id,
+                "seller": seller,
+                "available": available,
+                "price": price,
+                "list_price": list_price if list_price is not None else price,
+                "selling_price": selling_price if selling_price is not None else price,
+            }
+        return self
+
+    # ================================
+    # Internal helpers
+    # ================================
+    def _record(self, method: str, **kwargs) -> None:
+        self.calls.append((method, kwargs))
+
+    def _lookup_item(self, sku_id, seller_id, channel) -> Optional[dict]:
+        channel = str(channel) if channel is not None else None
+        key = (str(sku_id), str(seller_id), channel)
+        if key in self._items:
+            return self._items[key]
+        # Fall back to a channel-agnostic registration for ergonomics.
+        return self._items.get((str(sku_id), str(seller_id), None))
+
+    # ================================
+    # VTEX client contract
+    # ================================
+    def check_domain(self, domain) -> bool:
+        self._record("check_domain", domain=domain)
+        return self.domain_valid
+
+    def is_valid_credentials(self, domain) -> bool:
+        self._record("is_valid_credentials", domain=domain)
+        return self.credentials_valid
+
+    def list_active_sellers(self, domain, sales_channel=None) -> List[str]:
+        self._record("list_active_sellers", domain=domain, sales_channel=sales_channel)
+        return list(self._sellers)
+
+    def list_all_products_sku_ids(
+        self, domain, page_size=100000, sales_channel=None
+    ) -> List[str]:
+        self._record(
+            "list_all_products_sku_ids",
+            domain=domain,
+            page_size=page_size,
+            sales_channel=sales_channel,
+        )
+        return list(self._details.keys())
+
+    def get_product_details(self, sku_id, domain) -> Dict[str, Any]:
+        self._record("get_product_details", sku_id=sku_id, domain=domain)
+        details = self._details.get(str(sku_id))
+        if details is None:
+            raise CustomAPIException(detail=f"SKU {sku_id} not found", status_code=404)
+        return details
+
+    def get_product_specification(self, product_id, domain) -> Any:
+        self._record("get_product_specification", product_id=product_id, domain=domain)
+        return self._specs.get(str(product_id), [])
+
+    def pub_simulate_cart_for_seller(
+        self, sku_id, seller_id, domain, sales_channel=None
+    ) -> Dict[str, Any]:
+        self._record(
+            "pub_simulate_cart_for_seller",
+            sku_id=sku_id,
+            seller_id=seller_id,
+            domain=domain,
+            sales_channel=sales_channel,
+        )
+        item = self._lookup_item(sku_id, seller_id, sales_channel)
+        if item is None:
+            return {"is_available": False, "price": 0, "list_price": 0}
+
+        order_form = build_order_form_simulation([item])
+        return normalize_simulation_item(order_form["items"][0], order_form)
+
+    def simulate_cart_for_multiple_sellers(
+        self, sku_id, sellers, domain, sales_channel=None
+    ) -> Dict[str, Dict[str, Any]]:
+        self._record(
+            "simulate_cart_for_multiple_sellers",
+            sku_id=sku_id,
+            sellers=list(sellers),
+            domain=domain,
+            sales_channel=sales_channel,
+        )
+        raw_items = []
+        for seller in sellers:
+            item = self._lookup_item(sku_id, seller, sales_channel)
+            if item is not None:
+                raw_items.append(item)
+
+        order_form = build_order_form_simulation(raw_items)
+        return {
+            raw["seller"]: normalize_simulation_item(raw, order_form)
+            for raw in order_form["items"]
+        }

--- a/marketplace/services/vtex/tests/test_fakes.py
+++ b/marketplace/services/vtex/tests/test_fakes.py
@@ -1,0 +1,253 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase, override_settings
+
+from marketplace.clients.exceptions import CustomAPIException
+from marketplace.services.facebook.service import FacebookService
+from marketplace.services.vtex.private.products.service import PrivateProductsService
+from marketplace.services.vtex.tests.fakes import (
+    FakeFacebookCatalogClient,
+    FakeVtexClient,
+    VtexFakeTestCase,
+    VtexTestEnvironment,
+    build_sku_detail,
+)
+from marketplace.services.vtex.utils.data_processor import DataProcessor
+from marketplace.services.vtex.utils.enums import ProductPriority
+
+
+DOMAIN = "store.myvtex.com"
+
+
+class FakeVtexClientTest(TestCase):
+    """Contract tests for the in-memory VTEX fake."""
+
+    def test_credentials_and_domain_flags(self):
+        client = FakeVtexClient(domain_valid=False, credentials_valid=False)
+
+        self.assertFalse(client.check_domain(DOMAIN))
+        self.assertFalse(client.is_valid_credentials(DOMAIN))
+
+    def test_lists_registered_sellers_and_skus(self):
+        client = (
+            FakeVtexClient()
+            .add_product("1047", sellers=["1"])
+            .add_product("2099", sellers=["1", "2"])
+        )
+
+        self.assertEqual(sorted(client.list_active_sellers(DOMAIN)), ["1", "2"])
+        self.assertEqual(
+            sorted(client.list_all_products_sku_ids(DOMAIN)), ["1047", "2099"]
+        )
+
+    def test_get_product_details_returns_vtex_shape(self):
+        client = FakeVtexClient().add_product(
+            "1047", name="Laranja Bahia", brand="Arado"
+        )
+
+        details = client.get_product_details("1047", DOMAIN)
+
+        self.assertEqual(details["Id"], "1047")
+        self.assertEqual(details["SkuName"], "Laranja Bahia")
+        self.assertEqual(details["BrandName"], "Arado")
+        self.assertTrue(details["IsActive"])
+        self.assertEqual(details["SkuSellers"][0]["SellerId"], "1")
+
+    def test_get_product_details_raises_404_for_unknown_sku(self):
+        client = FakeVtexClient()
+
+        with self.assertRaises(CustomAPIException) as ctx:
+            client.get_product_details("404", DOMAIN)
+
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    def test_simulate_cart_for_seller_available(self):
+        client = FakeVtexClient().add_product(
+            "1047", sellers=["1"], available=True, price=1500, selling_price=1200
+        )
+
+        result = client.pub_simulate_cart_for_seller("1047", "1", DOMAIN)
+
+        self.assertTrue(result["is_available"])
+        self.assertEqual(result["price"], 1500)
+        self.assertEqual(result["selling_price"], 1200)
+        self.assertIn("data", result)
+
+    def test_simulate_cart_for_seller_unknown_returns_unavailable(self):
+        client = FakeVtexClient()
+
+        result = client.pub_simulate_cart_for_seller("999", "1", DOMAIN)
+
+        self.assertEqual(result, {"is_available": False, "price": 0, "list_price": 0})
+
+    def test_simulate_cart_for_multiple_sellers(self):
+        client = FakeVtexClient().add_product(
+            "1047", sellers=["1", "2"], available=True, price=1000
+        )
+
+        results = client.simulate_cart_for_multiple_sellers("1047", ["1", "2"], DOMAIN)
+
+        self.assertEqual(set(results.keys()), {"1", "2"})
+        self.assertTrue(results["1"]["is_available"])
+        self.assertTrue(results["2"]["is_available"])
+
+    def test_records_calls_as_spy(self):
+        client = FakeVtexClient().add_product("1047")
+
+        client.get_product_details("1047", DOMAIN)
+        client.list_active_sellers(DOMAIN)
+
+        recorded = [name for name, _ in client.calls]
+        self.assertIn("get_product_details", recorded)
+        self.assertIn("list_active_sellers", recorded)
+
+    def test_build_sku_detail_defaults(self):
+        detail = build_sku_detail("55", sellers=["7"])
+
+        self.assertEqual(detail["Id"], "55")
+        self.assertEqual(detail["SkuSellers"][0]["SellerId"], "7")
+        self.assertTrue(detail["Images"][0]["ImageUrl"])
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "vtex-fakes-service-tests",
+        }
+    }
+)
+class FakeVtexClientThroughServiceTest(TestCase):
+    """The fake is faithful enough to drive the real PrivateProductsService."""
+
+    def setUp(self):
+        self.client = FakeVtexClient().add_product(
+            "1047", sellers=["1"], available=True, price=1500
+        )
+        self.service = PrivateProductsService(self.client)
+
+    def test_validate_private_credentials(self):
+        self.assertTrue(self.service.validate_private_credentials(DOMAIN))
+
+    def test_list_all_skus_ids_uses_client(self):
+        self.assertEqual(self.service.list_all_skus_ids(DOMAIN), ["1047"])
+
+    def test_simulate_cart_for_seller_passthrough(self):
+        result = self.service.simulate_cart_for_seller("1047", "1", DOMAIN)
+
+        self.assertTrue(result["is_available"])
+        self.assertEqual(result["price"], 1500)
+
+
+class VtexTestEnvironmentTest(TestCase):
+    """The reusable environment wires DB fixtures + fakes consistently."""
+
+    def test_create_wires_apps_catalog_and_service(self):
+        env = VtexTestEnvironment.create()
+
+        self.assertEqual(env.vtex_app.code, "vtex")
+        self.assertEqual(env.wpp_cloud_app.code, "wpp-cloud")
+        self.assertEqual(env.catalog.vtex_app, env.vtex_app)
+        self.assertEqual(env.catalog.app, env.wpp_cloud_app)
+        self.assertEqual(env.project_uuid, str(env.vtex_app.project_uuid))
+        self.assertIsInstance(env.service, PrivateProductsService)
+
+    def test_add_product_is_visible_through_service(self):
+        env = VtexTestEnvironment.create().add_product("1047", price=1500)
+
+        details = env.service.get_product_details("1047", env.domain)
+
+        self.assertEqual(details["Id"], "1047")
+
+
+class FakeFacebookCatalogClientTest(TestCase):
+    """The Meta fake is faithful enough to drive the real FacebookService."""
+
+    def test_upload_batch_returns_handles_and_records_items(self):
+        client = FakeFacebookCatalogClient()
+        service = FacebookService(client)
+        payload = {
+            "item_type": "PRODUCT_ITEM",
+            "requests": [
+                {"method": "UPDATE", "data": {"id": "1047#1", "title": "Laranja"}}
+            ],
+        }
+
+        response = service.upload_batch("cat-123", payload)
+
+        self.assertTrue(response["handles"])
+        self.assertEqual(client.uploaded_items[0]["id"], "1047#1")
+        self.assertEqual(client.calls[0][0], "upload_items_batch")
+
+
+class FakeVtexClientDataProcessorTest(VtexFakeTestCase):
+    """
+    End-to-end: the environment feeds the real DataProcessor pipeline (API_ONLY
+    mode), producing faithful FacebookProductDTOs without touching VTEX, the DB
+    writes or redis.
+    """
+
+    def build_environment(self) -> VtexTestEnvironment:
+        env = VtexTestEnvironment.create(store_domain="www.arado.com.br")
+        env.add_product(
+            "1047",
+            sellers=["1"],
+            available=True,
+            price=1500,
+            selling_price=1200,
+            name="Laranja Bahia Importada",
+            brand="Arado",
+        )
+        return env
+
+    @patch("marketplace.services.vtex.utils.data_processor.close_old_connections")
+    @patch(
+        "marketplace.services.vtex.utils.sku_validator.get_redis_connection",
+        return_value=MagicMock(),
+    )
+    def test_process_produces_faithful_dto(self, _mock_redis, _mock_close):
+        processor = DataProcessor(use_threads=False)
+
+        results = processor.process(
+            items=["1047"],
+            catalog=self.vtex.catalog,
+            domain=self.vtex.domain,
+            service=self.vtex.service,
+            rules=[],
+            store_domain=self.vtex.store_domain,
+            mode="single",
+            sellers=["1"],
+            priority=ProductPriority.API_ONLY,
+        )
+
+        self.assertEqual(len(results), 1)
+        dto = results[0]
+        self.assertEqual(dto.id, "1047")
+        self.assertEqual(dto.availability, "in stock")
+        self.assertEqual(dto.brand, "Arado")
+        self.assertEqual(dto.price, 1500)
+        self.assertEqual(dto.sale_price, 1200)
+        self.assertEqual(dto.link, "https://www.arado.com.br/1047/p?idsku=1047")
+
+    @patch("marketplace.services.vtex.utils.data_processor.close_old_connections")
+    @patch(
+        "marketplace.services.vtex.utils.sku_validator.get_redis_connection",
+        return_value=MagicMock(),
+    )
+    def test_process_skips_unavailable_product(self, _mock_redis, _mock_close):
+        self.vtex.add_product("2099", sellers=["1"], available=False)
+        processor = DataProcessor(use_threads=False)
+
+        results = processor.process(
+            items=["2099"],
+            catalog=self.vtex.catalog,
+            domain=self.vtex.domain,
+            service=self.vtex.service,
+            rules=[],
+            store_domain=self.vtex.store_domain,
+            mode="single",
+            sellers=["1"],
+            priority=ProductPriority.API_ONLY,
+        )
+
+        self.assertEqual(results, [])

--- a/marketplace/settings.py
+++ b/marketplace/settings.py
@@ -519,3 +519,7 @@ SKU_VALIDATOR_TIMEOUT = env.int("SKU_VALIDATOR_TIMEOUT", default=1200)
 META_UPLOAD_PRODUCT_DELAY_DEFAULT = env.int(
     "META_UPLOAD_PRODUCT_DELAY_DEFAULT", default=30
 )
+
+# Maximum number of pre-formatted products accepted per on-demand upload request.
+# Matches Meta's items_batch ceiling of 5000 items per call.
+VTEX_UPLOAD_PRODUCTS_MAX_BATCH = env.int("VTEX_UPLOAD_PRODUCTS_MAX_BATCH", default=5000)


### PR DESCRIPTION
## What

Adds a new authenticated endpoint `POST /api/v1/apptypes/vtex/upload-inline-products/`
that uploads a list of pre-formatted (and optionally edited) products to the Meta
catalog. It reuses the inline endpoint's credentials model: the VTEX app is resolved
from the JWT `project_uuid` and its linked catalog drives the Meta upload. Products
arrive in the same shape returned by the inline sync endpoint (with `id` already
unified as `sku#seller`), are validated (required fields mirror the Meta business
rules; `price` is required when `in stock`), persisted to `UploadProduct` with
`ON_DEMAND` priority and uploaded asynchronously via the existing
`items_batch` pipeline. Request size is capped by `VTEX_UPLOAD_PRODUCTS_MAX_BATCH`
(default 5000, Meta's batch ceiling).

Layers: thin `VtexUploadInlineProductsView` → `UploadInlineProductsUseCase`
→ `ProductFacebookManager` + `UploadManager`. New `UploadInlineProductsDTO`
and serializers (`InlineProductItemSerializer`, `UploadInlineProductsSerializer`).

Also introduces a reusable VTEX/Meta test-double toolkit under
`marketplace/services/vtex/tests/fakes/` (`FakeVtexClient`,
`FakeFacebookCatalogClient`, `VtexTestEnvironment`, `VtexFakeTestCase`, payload
builders + README), already consumed by the upload integration test and proven
end-to-end through the real `DataProcessor` pipeline.

## Why

Enable end users to publish products to the Meta catalog directly from items
already formatted in our Meta standard, editing values (e.g. price) before
upload. The inline endpoint produces these pre-formatted products but is
read-only — there was no route to push the edited list back to Meta.
