### PR TITLE
feat: Add internal endpoint to list WhatsApp Cloud channels by project

### DIFF
--- a/marketplace/core/types/channels/whatsapp_cloud/serializers.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/serializers.py
@@ -27,3 +27,52 @@ class WhatsAppCloudConfigureSerializer(serializers.Serializer):
     waba_id = serializers.CharField(required=True)
     phone_number_id = serializers.CharField(required=True)
     auth_code = serializers.CharField(required=True)
+
+
+class WhatsAppCloudChannelsQueryParamsSerializer(serializers.Serializer):
+    project_uuid = serializers.UUIDField(required=True)
+
+
+class WhatsAppCloudChannelSerializer(serializers.Serializer):
+    """Represents a WhatsApp Cloud channel (App) for the channel-selection
+    screen consumed by external services such as `retail`.
+
+    `channel_uuid` is the App's `flow_object_uuid` (the identifier `retail`
+    uses as the channel) and `app_uuid` is the App's own uuid.
+
+    Phone number and display name may live either in the flat keys written at
+    creation time (`wa_number`, `wa_phone_number_id`, `wa_waba_id`,
+    `wa_verified_name`) or in the nested `phone_number` / `waba` objects written
+    later by the sync use cases. Both shapes are normalized here so the contract
+    is stable regardless of how far the channel has progressed through sync.
+
+    The raw `config` is intentionally not exposed: it holds secrets such as
+    `wa_user_token` and `wa_pin`.
+    """
+
+    def to_representation(self, instance: App) -> dict:
+        config = instance.config or {}
+        phone_number = config.get("phone_number") or {}
+        waba = config.get("waba") or {}
+
+        return {
+            "app_uuid": str(instance.uuid),
+            "channel_uuid": (
+                str(instance.flow_object_uuid) if instance.flow_object_uuid else None
+            ),
+            "phone_number": (
+                phone_number.get("display_phone_number")
+                or config.get("wa_number")
+                or config.get("title")
+            ),
+            "phone_number_id": (
+                phone_number.get("id") or config.get("wa_phone_number_id")
+            ),
+            "waba_id": waba.get("id") or config.get("wa_waba_id"),
+            "name": (
+                phone_number.get("display_name")
+                or config.get("wa_verified_name")
+                or waba.get("name")
+                or config.get("title")
+            ),
+        }

--- a/marketplace/core/types/channels/whatsapp_cloud/tests/test_views.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/tests/test_views.py
@@ -19,7 +19,7 @@ from marketplace.core.types.channels.whatsapp_base.exceptions import (
 from marketplace.core.types.channels.whatsapp_base.serializers import (
     WhatsAppBusinessContactSerializer,
 )
-from ..views import WhatsAppCloudViewSet
+from ..views import WhatsAppCloudViewSet, WhatsAppCloudChannelsView
 from rest_framework.exceptions import ValidationError
 
 
@@ -999,3 +999,129 @@ class UpdateMmliteStatusTestCase(APIBaseTestCase):
 
         response = self.request.patch(url, data, uuid=app_without_auth.uuid)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class ListWhatsAppCloudChannelsTestCase(PermissionTestCaseMixin, APIBaseTestCase):
+    view_class = WhatsAppCloudChannelsView
+
+    def setUp(self):
+        super().setUp()
+
+        self.project_uuid = str(uuid.uuid4())
+        self.other_project_uuid = str(uuid.uuid4())
+        self.url = reverse("wpp-cloud-channels")
+
+        self.grant_permission(self.user, "can_communicate_internally")
+
+    @property
+    def view(self):
+        return self.view_class.as_view()
+
+    def _create_app(self, project_uuid, config=None, flow_object_uuid=None):
+        return App.objects.create(
+            code="wpp-cloud",
+            created_by=self.user,
+            project_uuid=project_uuid,
+            platform=App.PLATFORM_WENI_FLOWS,
+            flow_object_uuid=flow_object_uuid or str(uuid.uuid4()),
+            config=config or {},
+        )
+
+    def test_list_returns_all_channels_of_the_project(self):
+        self._create_app(self.project_uuid)
+        self._create_app(self.project_uuid)
+        self._create_app(self.project_uuid)
+
+        response = self.request.get(
+            self.url, params={"project_uuid": self.project_uuid}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json), 3)
+
+    def test_list_returns_empty_list_when_project_has_no_channels(self):
+        response = self.request.get(
+            self.url, params={"project_uuid": self.project_uuid}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json, [])
+
+    def test_list_does_not_leak_channels_from_other_projects(self):
+        app = self._create_app(self.project_uuid)
+        self._create_app(self.other_project_uuid)
+
+        response = self.request.get(
+            self.url, params={"project_uuid": self.project_uuid}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json), 1)
+        self.assertEqual(response.json[0]["app_uuid"], str(app.uuid))
+
+    def test_list_requires_project_uuid(self):
+        response = self.request.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_list_denies_non_internal_user(self):
+        self.revoke_permission(self.user, "can_communicate_internally")
+
+        response = self.request.get(
+            self.url, params={"project_uuid": self.project_uuid}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_list_exposes_channel_identifiers_from_nested_config(self):
+        flow_object_uuid = str(uuid.uuid4())
+        app = self._create_app(
+            self.project_uuid,
+            flow_object_uuid=flow_object_uuid,
+            config={
+                "title": "+55 11 2148-4999",
+                "waba": {"id": "912460154934195", "name": "Agentic CX Staging"},
+                "phone_number": {
+                    "id": "1089390800916485",
+                    "display_name": "Agentic CX Staging",
+                    "display_phone_number": "+55 11 2148-4999",
+                },
+            },
+        )
+
+        response = self.request.get(
+            self.url, params={"project_uuid": self.project_uuid}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        channel = response.json[0]
+        self.assertEqual(channel["app_uuid"], str(app.uuid))
+        self.assertEqual(channel["channel_uuid"], flow_object_uuid)
+        self.assertEqual(channel["phone_number"], "+55 11 2148-4999")
+        self.assertEqual(channel["phone_number_id"], "1089390800916485")
+        self.assertEqual(channel["waba_id"], "912460154934195")
+        self.assertEqual(channel["name"], "Agentic CX Staging")
+        self.assertNotIn("config", channel)
+
+    def test_list_exposes_channel_identifiers_from_flat_config(self):
+        app = self._create_app(
+            self.project_uuid,
+            config={
+                "wa_number": "+55 84 99999-0000",
+                "wa_phone_number_id": "111222333",
+                "wa_waba_id": "444555666",
+                "wa_verified_name": "Order Status",
+            },
+        )
+
+        response = self.request.get(
+            self.url, params={"project_uuid": self.project_uuid}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        channel = response.json[0]
+        self.assertEqual(channel["app_uuid"], str(app.uuid))
+        self.assertEqual(channel["phone_number"], "+55 84 99999-0000")
+        self.assertEqual(channel["phone_number_id"], "111222333")
+        self.assertEqual(channel["waba_id"], "444555666")
+        self.assertEqual(channel["name"], "Order Status")

--- a/marketplace/core/types/channels/whatsapp_cloud/usecases/list_channels.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/usecases/list_channels.py
@@ -1,0 +1,22 @@
+from typing import Type
+
+from django.db.models import QuerySet
+
+from marketplace.applications.models import App
+
+
+class ListWhatsAppCloudChannelsUseCase:
+    """Return every WhatsApp Cloud channel (App) of a project.
+
+    The slug is referenced by literal (instead of importing
+    `WhatsAppCloudType`) to avoid the `type -> views -> usecases` import cycle,
+    matching how other modules query these apps.
+    """
+
+    CODE = "wpp-cloud"
+
+    def __init__(self, app_model: Type[App] = App):
+        self._app_model = app_model
+
+    def execute(self, project_uuid) -> "QuerySet[App]":
+        return self._app_model.objects.filter(code=self.CODE, project_uuid=project_uuid)

--- a/marketplace/core/types/channels/whatsapp_cloud/usecases/tests/test_list_channels.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/usecases/tests/test_list_channels.py
@@ -1,0 +1,58 @@
+import uuid
+
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from marketplace.applications.models import App
+from marketplace.core.types.channels.whatsapp_cloud.usecases.list_channels import (
+    ListWhatsAppCloudChannelsUseCase,
+)
+
+
+User = get_user_model()
+
+
+class ListWhatsAppCloudChannelsUseCaseTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(email="user@marketplace.ai")
+        self.project_uuid = str(uuid.uuid4())
+        self.other_project_uuid = str(uuid.uuid4())
+        self.use_case = ListWhatsAppCloudChannelsUseCase()
+
+    def _create_app(self, project_uuid, code="wpp-cloud"):
+        return App.objects.create(
+            code=code,
+            created_by=self.user,
+            project_uuid=project_uuid,
+            platform=App.PLATFORM_WENI_FLOWS,
+            flow_object_uuid=str(uuid.uuid4()),
+        )
+
+    def test_execute_returns_channels_of_the_project(self):
+        self._create_app(self.project_uuid)
+        self._create_app(self.project_uuid)
+
+        apps = self.use_case.execute(project_uuid=self.project_uuid)
+
+        self.assertEqual(apps.count(), 2)
+
+    def test_execute_returns_empty_queryset_when_project_has_no_channels(self):
+        apps = self.use_case.execute(project_uuid=self.project_uuid)
+
+        self.assertEqual(apps.count(), 0)
+
+    def test_execute_does_not_return_channels_of_other_projects(self):
+        app = self._create_app(self.project_uuid)
+        self._create_app(self.other_project_uuid)
+
+        apps = self.use_case.execute(project_uuid=self.project_uuid)
+
+        self.assertEqual(list(apps), [app])
+
+    def test_execute_only_returns_wpp_cloud_apps(self):
+        wpp_cloud_app = self._create_app(self.project_uuid)
+        self._create_app(self.project_uuid, code="wpp")
+
+        apps = self.use_case.execute(project_uuid=self.project_uuid)
+
+        self.assertEqual(list(apps), [wpp_cloud_app])

--- a/marketplace/core/types/channels/whatsapp_cloud/views.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/views.py
@@ -41,7 +41,12 @@ from marketplace.internal.permissions import CanCommunicateInternally
 
 from ..whatsapp_base import mixins
 from ..whatsapp_base.serializers import WhatsAppSerializer
-from .serializers import WhatsAppCloudConfigureSerializer
+from .serializers import (
+    WhatsAppCloudConfigureSerializer,
+    WhatsAppCloudChannelSerializer,
+    WhatsAppCloudChannelsQueryParamsSerializer,
+)
+from .usecases.list_channels import ListWhatsAppCloudChannelsUseCase
 from .facades import CloudProfileFacade, CloudProfileContactFacade
 
 if TYPE_CHECKING:
@@ -297,6 +302,29 @@ class WhatsAppCloudViewSet(
             return Response(
                 {"app": serializer.data, "calling": details}, status=status.HTTP_200_OK
             )
+
+
+class WhatsAppCloudChannelsView(APIView):
+    """List every WhatsApp Cloud channel of a project for the channel-selection
+    screen consumed by internal services (e.g. retail).
+
+    Always scoped to the required `project_uuid`, so other projects' channels
+    are never leaked.
+    """
+
+    permission_classes = [CanCommunicateInternally]
+
+    def get(self, request, *args, **kwargs):
+        serializer = WhatsAppCloudChannelsQueryParamsSerializer(
+            data=request.query_params
+        )
+        serializer.is_valid(raise_exception=True)
+
+        apps = ListWhatsAppCloudChannelsUseCase().execute(
+            project_uuid=serializer.validated_data["project_uuid"]
+        )
+
+        return Response(WhatsAppCloudChannelSerializer(apps, many=True).data)
 
 
 class WhatsAppCloudInsights(APIView):

--- a/marketplace/core/types/urls.py
+++ b/marketplace/core/types/urls.py
@@ -2,7 +2,10 @@ from django.urls import path, include
 from rest_framework_nested import routers
 
 from marketplace.core import types
-from marketplace.core.types.channels.whatsapp_cloud.views import WhatsAppCloudInsights
+from marketplace.core.types.channels.whatsapp_cloud.views import (
+    WhatsAppCloudInsights,
+    WhatsAppCloudChannelsView,
+)
 
 
 urlpatterns = []
@@ -42,6 +45,14 @@ urlpatterns.append(
         "apptypes/wpp-cloud/list_wpp-cloud/<uuid:project_uuid>/",
         WhatsAppCloudInsights.as_view(),
         name="wpp-cloud-insights",
+    )
+)
+
+urlpatterns.append(
+    path(
+        "apptypes/wpp-cloud/channels/",
+        WhatsAppCloudChannelsView.as_view(),
+        name="wpp-cloud-channels",
     )
 )
 # Facebook


### PR DESCRIPTION
## What

Adds `GET /api/v1/apptypes/wpp-cloud/channels/?project_uuid=<uuid>`, an internal
endpoint (`CanCommunicateInternally`) that returns every WhatsApp Cloud channel
(App) of a project for the channel-selection screen consumed by other services
(e.g. retail). Each item exposes `app_uuid`, `channel_uuid` (the App's
`flow_object_uuid`), `phone_number`, `phone_number_id`, `waba_id` and `name`.

Implemented as a dedicated `APIView` following the project's layered
architecture and matching the existing internal endpoints
(`WhatsAppCloudInsights`, `CheckAppIsIntegrated`):
- `WhatsAppCloudChannelsQueryParamsSerializer` validates the query param.
- `ListWhatsAppCloudChannelsUseCase` owns the ORM query, always scoped to the
  required `project_uuid` (multi-tenant isolation).
- `WhatsAppCloudChannelSerializer` normalizes name/phone from both the flat
  legacy config keys and the nested `phone_number`/`waba` objects written by the
  sync use cases. The raw `config` is intentionally omitted because it holds
  secrets (`wa_user_token`, `wa_pin`).

## Why

Agentic CX needs to list all WhatsApp Cloud channels of a project so an agent can be
assigned to a specific channel. No existing endpoint returned the full set of
identifiers scoped by project (prior endpoints returned a single app or lacked
`channel_uuid`/`phone_number_id`).
