### PR TITLE
fix: Avoid double-applying area multiplier on VTEX sale_price

### DIFF
--- a/marketplace/services/vtex/business/rules/calculate_by_area.py
+++ b/marketplace/services/vtex/business/rules/calculate_by_area.py
@@ -3,18 +3,21 @@ from marketplace.services.vtex.utils.data_processor import FacebookProductDTO
 
 
 class CalculateByArea(Rule):
+    """Convert area-based prices (m²) to the price per packaged unit.
+
+    VTEX returns ``listPrice`` per square meter, while the cart simulation
+    already applies the ``UnitMultiplier`` to ``sellingPrice`` (the real
+    checkout price per box). Only ``price`` must be multiplied here;
+    multiplying ``sale_price`` again would apply the multiplier twice.
+    """
+
     def apply(self, product: FacebookProductDTO, **kwargs) -> bool:
         if self._calculate_by_area(product):
-            unit_multiplier = self._get_multiplier(product)
-            product.price *= unit_multiplier
-            product.sale_price *= unit_multiplier
+            product.price *= self._get_multiplier(product)
         return True
 
-    def _calculate_by_area(self, product: FacebookProductDTO):
-        measurementUnit = product.product_details.get("MeasurementUnit", "")
-        if len(measurementUnit) > 0 and measurementUnit == "m²":
-            return True
-        return False
+    def _calculate_by_area(self, product: FacebookProductDTO) -> bool:
+        return product.product_details.get("MeasurementUnit", "") == "m²"
 
-    def _get_multiplier(self, product: FacebookProductDTO):
+    def _get_multiplier(self, product: FacebookProductDTO) -> float:
         return product.product_details.get("UnitMultiplier", 1.0)

--- a/marketplace/services/vtex/business/rules/tests/test_calculate_by_area.py
+++ b/marketplace/services/vtex/business/rules/tests/test_calculate_by_area.py
@@ -28,7 +28,31 @@ class TestCalculateByArea(TestCase):
 
         self.assertTrue(result)
         self.assertEqual(product.price, 25000)  # 10000 * 2.5
-        self.assertEqual(product.sale_price, 20000)  # 8000 * 2.5
+        # sale_price is left untouched: VTEX already applies the multiplier to it
+        self.assertEqual(product.sale_price, 8000)
+
+    def test_apply_does_not_double_apply_multiplier_on_sale_price(self):
+        """sale_price already comes multiplied from VTEX; only price is converted."""
+        product = FacebookProductDTO(
+            id="45418",
+            title="Revestimento Venatino Lux",
+            description="Revestimento por metro quadrado",
+            availability="in stock",
+            status="active",
+            condition="new",
+            price=12900,  # listPrice per m² (R$129.00)
+            sale_price=10449,  # sellingPrice already per box (12900 * 0.81)
+            link="http://example.com/product",
+            image_link="http://example.com/image.jpg",
+            brand="Incepa",
+            product_details={"MeasurementUnit": "m²", "UnitMultiplier": 0.81},
+        )
+
+        result = self.rule.apply(product)
+
+        self.assertTrue(result)
+        self.assertEqual(product.price, 10449.0)  # 12900 * 0.81
+        self.assertEqual(product.sale_price, 10449)  # unchanged
 
     def test_apply_without_area_calculation(self):
         """Test apply method when product should not be calculated by area"""

--- a/marketplace/services/vtex/business/rules/tests/test_calculate_by_area_simplified.py
+++ b/marketplace/services/vtex/business/rules/tests/test_calculate_by_area_simplified.py
@@ -38,7 +38,8 @@ class TestCalculateByArea(TestCase):
 
         self.assertTrue(result)
         self.assertEqual(product.price, 25000)  # 10000 * 2.5
-        self.assertEqual(product.sale_price, 20000)  # 8000 * 2.5
+        # sale_price is left untouched: VTEX already applies the multiplier to it
+        self.assertEqual(product.sale_price, 8000)
 
     def test_apply_without_area_calculation(self):
         """Test apply method when product should not be calculated by area"""


### PR DESCRIPTION
## What

The `CalculateByArea` rule used to multiply both `price` and `sale_price`
by the product's `UnitMultiplier`. However, VTEX's cart simulation already
returns `sellingPrice` (mapped to `sale_price`) with the multiplier applied
(the real per-box checkout price), while `listPrice` (mapped to `price`)
comes per square meter. Multiplying `sale_price` again applied the factor
twice, producing a promotional price ~19% below the real value (e.g.
R$ 84.63 instead of R$ 104.49 for SKU 45418).

This change makes the rule multiply only `price`, leaving `sale_price`
untouched. It also simplifies `_calculate_by_area`, adds return type hints,
and documents the VTEX pricing behavior in the class docstring. Tests were
updated and a regression test based on the real client data (SKU 45418)
was added.

## Why

A customer reported wrong prices in the Meta catalog: the promotional price
shown was lower than the actual checkout price for area-based (m²) products,
caused by the double multiplication.
