### PR TITLE
fix: Update WhatsApp currency from USD to BRL across multiple components

### DIFF
--- a/marketplace/core/types/channels/whatsapp_cloud/tests/test_views.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/tests/test_views.py
@@ -576,7 +576,7 @@ class CreateWhatsAppCloudTestCase(APIBaseTestCase):
         self.assertEqual(app.config["wa_number"], "mock_display_phone_number")
         self.assertEqual(app.config["wa_verified_name"], "mock_verified_name")
         self.assertEqual(app.config["wa_waba_id"], self.payload["waba_id"])
-        self.assertEqual(app.config["wa_currency"], "USD")
+        self.assertEqual(app.config["wa_currency"], "BRL")
         self.assertEqual(app.config["wa_business_id"], "mock_business_id")
         self.assertEqual(
             app.config["wa_message_template_namespace"],

--- a/marketplace/core/types/channels/whatsapp_cloud/views.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/views.py
@@ -113,7 +113,7 @@ class WhatsAppCloudViewSet(
         waba_id = serializer.validated_data.get("waba_id")
         phone_number_id = serializer.validated_data.get("phone_number_id")
         auth_code = serializer.validated_data.get("auth_code")
-        waba_currency = "USD"
+        waba_currency = "BRL"
 
         whatsapp_system_user_access_token = settings.WHATSAPP_SYSTEM_USER_ACCESS_TOKEN
         facebook_client = FacebookClient(whatsapp_system_user_access_token)

--- a/marketplace/core/types/channels/whatsapp_demo/type.py
+++ b/marketplace/core/types/channels/whatsapp_demo/type.py
@@ -52,7 +52,7 @@ class WhatsAppDemoType(AppType):
             wa_number=cls.NUMBER,
             wa_verified_name=cls.VERIFIED_NAME,
             wa_waba_id=None,
-            wa_currency="USD",
+            wa_currency="BRL",
             wa_business_id=cls.BUSINESS_ID,
             wa_message_template_namespace=None,
             wa_pin=None,

--- a/marketplace/services/facebook/tests/test_services.py
+++ b/marketplace/services/facebook/tests/test_services.py
@@ -435,7 +435,7 @@ class TestBusinessMetaService(TestCase):
         self.assertEqual(response, {"success": True})
 
     def test_share_credit_line(self):
-        response = self.service.share_credit_line("waba_id", "USD")
+        response = self.service.share_credit_line("waba_id", "BRL")
         self.assertEqual(response, {"allocation_config_id": "mock_allocation_id"})
 
     def test_subscribe_app(self):
@@ -450,7 +450,7 @@ class TestBusinessMetaService(TestCase):
 
     def test_configure_whatsapp_cloud(self):
         response = self.service.configure_whatsapp_cloud(
-            "auth_code", "waba_id", "phone_number_id", "USD"
+            "auth_code", "waba_id", "phone_number_id", "BRL"
         )
         self.assertEqual(
             response,
@@ -469,7 +469,7 @@ class TestBusinessMetaService(TestCase):
         try:
             self.service.create_dataset = Mock(side_effect=Exception("dataset failure"))
             response = self.service.configure_whatsapp_cloud(
-                "auth_code", "waba_id", "phone_number_id", "USD"
+                "auth_code", "waba_id", "phone_number_id", "BRL"
             )
             self.assertEqual(
                 response,

--- a/marketplace/services/flows/tests/test_service.py
+++ b/marketplace/services/flows/tests/test_service.py
@@ -14,7 +14,7 @@ MOCK_CONFIG = {
     "wa_pin": "12345678",
     "wa_number": "+55 84 99999-9999",
     "wa_waba_id": "123456789",
-    "wa_currency": "USD",
+    "wa_currency": "BRL",
     "wa_business_id": "202020202020",
     "wa_phone_number_id": "0123456789",
 }


### PR DESCRIPTION
### TL;DR

Changed the default WhatsApp currency from `USD` to `BRL`.

### What changed?

The default currency used when configuring WhatsApp Cloud and WhatsApp Demo channels has been updated from `USD` to `BRL`. This affects the `wa_currency` field set during app creation and channel configuration, as well as the credit line sharing process.

### Why make this change?

The default currency for our Meta credit line is now BRL