### PR TITLE
feat: Implement template category update handling in TemplateWebhookEventProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v4.22.0
+----------
+* feat: Implement stale cache mechanism for preverified phone numbers
+* feat: Implement template category update handling in TemplateWebhookEventProcessor
+
 v4.21.1
 ----------
 * fix: Update WhatsApp currency from USD to BRL across multiple components

--- a/marketplace/wpp_templates/factories.py
+++ b/marketplace/wpp_templates/factories.py
@@ -32,4 +32,5 @@ def create_template_webhook_event_processor() -> TemplateWebhookEventProcessor:
     return TemplateWebhookEventProcessor(
         status_update_handler=status_update_handler,
         category_change_handler=category_change_handler,
+        flows_service=flows_service,
     )

--- a/marketplace/wpp_templates/tasks.py
+++ b/marketplace/wpp_templates/tasks.py
@@ -85,6 +85,7 @@ def update_templates_by_webhook(**kwargs):  # pragma: no cover
     allowed_event_types = [
         "message_template_status_update",
         "template_correct_category_detection",
+        "template_category_update",
     ]
     webhook_data = kwargs.get("webhook_data")
 

--- a/marketplace/wpp_templates/tests/test_utils.py
+++ b/marketplace/wpp_templates/tests/test_utils.py
@@ -234,6 +234,41 @@ class TestTemplateWebhookEventProcessor(TestCase):
             webhook=webhook,
         )
 
+    @patch("marketplace.wpp_templates.utils.extract_template_data")
+    def test_process_template_category_update_logs_flows_error_on_webhook_failure(
+        self, mock_extract
+    ):
+        mock_extract.return_value = {"mocked": "data"}
+        mock_app = MagicMock()
+        mock_app.uuid = "app-uuid-1"
+        mock_app.flow_object_uuid = "flow-uuid-1"
+        self.mock_app_filter.return_value.exists.return_value = True
+        self.mock_app_filter.return_value.__iter__.return_value = [mock_app]
+
+        mock_template = MagicMock()
+        mock_template.name = "promo"
+        mock_translation = MagicMock()
+        mock_translation.language = "en_US"
+        mock_template.translations.all.return_value = [mock_translation]
+        self.mock_template_filter.return_value.first.return_value = mock_template
+
+        self.flows_service.update_facebook_templates_webhook.side_effect = Exception(
+            "flows down"
+        )
+        self.processor.logger = MagicMock()
+
+        value = {
+            "message_template_name": "promo",
+            "previous_category": "UTILITY",
+            "new_category": "MARKETING",
+        }
+        self.processor.process_template_category_update("waba-1", value, {"entry": []})
+
+        self.processor.logger.error.assert_called_once_with(
+            "[Flows] Failed to send category update for promo/en_US: flows down"
+        )
+        mock_template.save.assert_called_once()
+
     def test_process_template_category_update_skips_missing_template(self):
         mock_app = MagicMock()
         mock_app.uuid = "app-uuid-1"

--- a/marketplace/wpp_templates/tests/test_utils.py
+++ b/marketplace/wpp_templates/tests/test_utils.py
@@ -22,9 +22,11 @@ class TestTemplateWebhookEventProcessor(TestCase):
         ).start()
         self.status_update_handler = MagicMock()
         self.category_change_handler = MagicMock()
+        self.flows_service = MagicMock()
         self.processor = TemplateWebhookEventProcessor(
             status_update_handler=self.status_update_handler,
             category_change_handler=self.category_change_handler,
+            flows_service=self.flows_service,
         )
         self.addCleanup(patch.stopall)
 
@@ -155,6 +157,138 @@ class TestTemplateWebhookEventProcessor(TestCase):
                 "correct_category": "MARKETING",
             },
         )
+
+    def test_process_event_routes_template_category_update(self):
+        self.processor.process_template_category_update = MagicMock()
+
+        value = {
+            "message_template_name": "promo",
+            "previous_category": "UTILITY",
+            "new_category": "MARKETING",
+        }
+        self.processor.process_event(
+            "waba-1", value, "template_category_update", {"entry": []}
+        )
+
+        self.processor.process_template_category_update.assert_called_once_with(
+            "waba-1", value, {"entry": []}
+        )
+
+    def test_process_template_category_update_skips_impending(self):
+        self.processor.logger = MagicMock()
+
+        value = {
+            "message_template_name": "promo",
+            "correct_category": "MARKETING",
+            "new_category": "UTILITY",
+            "category_update_timestamp": 1746169200,
+        }
+        self.processor.process_template_category_update("waba-1", value, {})
+
+        self.mock_app_filter.return_value.exists.assert_not_called()
+        self.processor.logger.info.assert_called()
+
+    def test_process_template_category_update_no_apps(self):
+        self.mock_app_filter.return_value.exists.return_value = False
+
+        value = {
+            "message_template_name": "promo",
+            "previous_category": "UTILITY",
+            "new_category": "MARKETING",
+        }
+        self.processor.process_template_category_update("waba-1", value, {})
+
+        self.mock_template_filter.assert_not_called()
+
+    @patch("marketplace.wpp_templates.utils.extract_template_data")
+    def test_process_template_category_update_updates_and_notifies(
+        self, mock_extract
+    ):
+        mock_extract.return_value = {"mocked": "data"}
+        mock_app = MagicMock()
+        mock_app.uuid = "app-uuid-1"
+        mock_app.flow_object_uuid = "flow-uuid-1"
+        self.mock_app_filter.return_value.exists.return_value = True
+        self.mock_app_filter.return_value.__iter__.return_value = [mock_app]
+
+        mock_template = MagicMock()
+        mock_template.name = "promo"
+        mock_translation = MagicMock()
+        mock_template.translations.all.return_value = [mock_translation]
+        self.mock_template_filter.return_value.first.return_value = mock_template
+
+        value = {
+            "message_template_name": "promo",
+            "previous_category": "UTILITY",
+            "new_category": "MARKETING",
+        }
+        webhook = {"entry": [{"changes": []}]}
+        self.processor.process_template_category_update("waba-1", value, webhook)
+
+        self.assertEqual(mock_template.category, "MARKETING")
+        mock_template.save.assert_called_once()
+        self.flows_service.update_facebook_templates_webhook.assert_called_once_with(
+            flow_object_uuid="flow-uuid-1",
+            template_data={"mocked": "data"},
+            template_name="promo",
+            webhook=webhook,
+        )
+
+    def test_process_template_category_update_skips_missing_template(self):
+        mock_app = MagicMock()
+        mock_app.uuid = "app-uuid-1"
+        self.mock_app_filter.return_value.exists.return_value = True
+        self.mock_app_filter.return_value.__iter__.return_value = [mock_app]
+        self.mock_template_filter.return_value.first.return_value = None
+
+        value = {
+            "message_template_name": "missing",
+            "previous_category": "UTILITY",
+            "new_category": "MARKETING",
+        }
+        self.processor.process_template_category_update("waba-1", value, {})
+
+        self.flows_service.update_facebook_templates_webhook.assert_not_called()
+
+    @patch("marketplace.wpp_templates.utils.extract_template_data")
+    def test_process_template_category_update_error_does_not_stop_others(
+        self, mock_extract
+    ):
+        mock_extract.return_value = {"mocked": "data"}
+        app_one = MagicMock()
+        app_one.uuid = "app-1"
+        app_one.flow_object_uuid = "flow-1"
+        app_two = MagicMock()
+        app_two.uuid = "app-2"
+        app_two.flow_object_uuid = "flow-2"
+
+        self.mock_app_filter.return_value.exists.return_value = True
+        self.mock_app_filter.return_value.__iter__.return_value = [app_one, app_two]
+
+        template_one = MagicMock()
+        template_one.name = "promo"
+        template_one.translations.all.side_effect = Exception("DB error")
+
+        template_two = MagicMock()
+        template_two.name = "promo"
+        mock_translation = MagicMock()
+        template_two.translations.all.return_value = [mock_translation]
+
+        self.mock_template_filter.return_value.first.side_effect = [
+            template_one,
+            template_two,
+        ]
+
+        self.processor.logger = MagicMock()
+        value = {
+            "message_template_name": "promo",
+            "previous_category": "UTILITY",
+            "new_category": "MARKETING",
+        }
+        self.processor.process_template_category_update("waba-1", value, {"entry": []})
+
+        self.processor.logger.error.assert_called_once()
+        self.flows_service.update_facebook_templates_webhook.assert_called_once()
 
 
 class TestTemplateCategoryChangeHandler(TestCase):

--- a/marketplace/wpp_templates/utils.py
+++ b/marketplace/wpp_templates/utils.py
@@ -171,10 +171,12 @@ class TemplateWebhookEventProcessor:
         self,
         status_update_handler: TemplateStatusUpdateHandler,
         category_change_handler: TemplateCategoryChangeHandler,
+        flows_service: "FlowsService",
         logger: Optional[logging.Logger] = None,
     ):
         self.status_update_handler = status_update_handler
         self.category_change_handler = category_change_handler
+        self.flows_service = flows_service
         self.logger = logger or logging.getLogger(__name__)
 
     def get_apps_by_waba_id(self, waba_id: str):
@@ -227,6 +229,68 @@ class TemplateWebhookEventProcessor:
         for app in apps:
             self.category_change_handler.handle(app=app, value=value)
 
+    def process_template_category_update(
+        self, waba_id: str, value: dict, webhook: dict
+    ) -> None:
+        """
+        Handles template_category_update events from Meta.
+        Only processes completed category changes (when previous_category is present).
+        Updates category locally and notifies Flows via POST /template-sync/.
+        """
+        previous_category = value.get("previous_category")
+        if not previous_category:
+            self.logger.info(
+                f"Impending category change for template "
+                f"{value.get('message_template_name')}, skipping."
+            )
+            return
+
+        new_category = value.get("new_category")
+        template_name = value.get("message_template_name")
+
+        apps = self.get_apps_by_waba_id(waba_id)
+        if not apps.exists():
+            self.logger.info(f"There are no applications linked to waba: {waba_id}")
+            return
+
+        for app in apps:
+            try:
+                template = TemplateMessage.objects.filter(
+                    app=app, name=template_name
+                ).first()
+                if not template:
+                    continue
+
+                template.category = new_category
+                template.save()
+                self.logger.info(
+                    f"Template {template_name} category updated from "
+                    f"{previous_category} to {new_category} for app {app.uuid}"
+                )
+
+                for translation in template.translations.all():
+                    try:
+                        template_data = extract_template_data(translation)
+                        self.flows_service.update_facebook_templates_webhook(
+                            flow_object_uuid=str(app.flow_object_uuid),
+                            template_data=template_data,
+                            template_name=template.name,
+                            webhook=webhook,
+                        )
+                        self.logger.info(
+                            f"[Flows] Category update for {template.name}/"
+                            f"{translation.language} sent."
+                        )
+                    except Exception as e:
+                        self.logger.error(
+                            f"[Flows] Failed to send category update for "
+                            f"{template.name}/{translation.language}: {e}"
+                        )
+            except Exception as e:
+                self.logger.error(
+                    f"Error processing category update for App {str(app.uuid)}: {e}"
+                )
+
     def process_event(
         self, waba_id: str, value: dict, event_type: str, webhook: dict
     ) -> None:
@@ -234,6 +298,8 @@ class TemplateWebhookEventProcessor:
             self.process_template_status_update(waba_id, value, webhook)
         elif event_type == "template_correct_category_detection":
             self.process_template_category_change(waba_id, value)
+        elif event_type == "template_category_update":
+            self.process_template_category_update(waba_id, value, webhook)
 
 
 def extract_template_data(translation: TemplateTranslation) -> dict:


### PR DESCRIPTION
- Added a new method to process template category update events, updating the category of templates and notifying the Flows service.
- Updated the event processing logic to route to the new category update method.
- Enhanced the TemplateWebhookEventProcessor constructor to include a flows_service parameter.
- Added tests to ensure correct handling of category updates and edge cases.