### PR TITLE
feat(whatsapp): expose currency_migration info in config serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v4.23.1
+----------
+* feat(whatsapp): expose currency_migration info in config serializer
+
 v4.23.0
 ----------
 * feat: Adopt weni-commons JWT authentication on channel routes

--- a/marketplace/core/types/channels/whatsapp/tests/test_views.py
+++ b/marketplace/core/types/channels/whatsapp/tests/test_views.py
@@ -49,7 +49,7 @@ class RetrieveWhatsAppTestCase(APIBaseTestCase):
         self.assertIn("project_uuid", response.json)
         self.assertIn("platform", response.json)
         self.assertIn("created_on", response.json)
-        self.assertEqual(response.json["config"], {})
+        self.assertEqual(response.json["config"], {"currency_migration": None})
 
 
 class DestroyWhatsAppTestCase(APIBaseTestCase):

--- a/marketplace/core/types/channels/whatsapp_base/serializers.py
+++ b/marketplace/core/types/channels/whatsapp_base/serializers.py
@@ -36,6 +36,11 @@ class WhatsAppConfigPhoneNumberSerializer(serializers.Serializer):
     certificate = serializers.CharField(required=False)
 
 
+class CurrencyMigrationSerializer(serializers.Serializer):
+    migration_date = serializers.CharField(source="migrated_at", allow_null=True)
+    old_waba_id = serializers.CharField(source="wa_waba_id", allow_null=True)
+
+
 class WhatsAppConfigSerializer(serializers.Serializer):
     title = serializers.CharField(required=False)
     waba = WhatsAppConfigWABASerializer(required=False)
@@ -44,6 +49,11 @@ class WhatsAppConfigSerializer(serializers.Serializer):
     mmlite_status = serializers.CharField(required=False)
     has_calling = serializers.BooleanField(required=False)
     direct_send = serializers.BooleanField(required=False)
+    currency_migration = CurrencyMigrationSerializer(
+        source="currency_migration_previous_waba_info",
+        required=False,
+        allow_null=True,
+    )
 
 
 class WhatsAppSerializer(AppTypeBaseSerializer):

--- a/marketplace/core/types/channels/whatsapp_cloud/tests/test_views.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/tests/test_views.py
@@ -66,7 +66,7 @@ class RetrieveWhatsAppCloudTestCase(APIBaseTestCase):
         self.assertIn("project_uuid", response.json)
         self.assertIn("platform", response.json)
         self.assertIn("created_on", response.json)
-        self.assertEqual(response.json["config"], {})
+        self.assertEqual(response.json["config"], {"currency_migration": None})
 
     def test_retrieve_exposes_phone_number_id_and_waba_id(self):
         self.app.config = {
@@ -100,6 +100,42 @@ class RetrieveWhatsAppCloudTestCase(APIBaseTestCase):
         self.assertEqual(config["waba"]["id"], "912460154934195")
 
         self.assertNotIn("wa_phone_number_id", config)
+        self.assertIsNone(config["currency_migration"])
+
+    def test_retrieve_exposes_currency_migration(self):
+        migrated_at = "2026-08-06T18:00:00.123456+00:00"
+        old_waba_id = "111222333444"
+        self.app.config = {
+            "wa_waba_id": "999888777666",
+            "currency_migration_previous_waba_info": {
+                "wa_waba_id": old_waba_id,
+                "wa_currency": "USD",
+                "wa_message_template_namespace": "old-namespace",
+                "waba": {"id": old_waba_id, "name": "Old WABA"},
+                "migrated_at": migrated_at,
+                "template_id_mappings": [
+                    {
+                        "template_name": "hello",
+                        "language": "en",
+                        "old_message_template_id": "1",
+                        "new_message_template_id": "2",
+                    }
+                ],
+            },
+        }
+        self.app.save()
+
+        response = self.request.get(self.url, uuid=self.app.uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        config = response.json["config"]
+        self.assertEqual(
+            config["currency_migration"],
+            {"migration_date": migrated_at, "old_waba_id": old_waba_id},
+        )
+        self.assertNotIn("currency_migration_previous_waba_info", config)
+        self.assertNotIn("template_id_mappings", config["currency_migration"])
 
 
 class DestroyWhatsAppCloudTestCase(APIBaseTestCase):

--- a/marketplace/swagger.py
+++ b/marketplace/swagger.py
@@ -6,7 +6,7 @@ from rest_framework import permissions
 view = get_schema_view(
     openapi.Info(
         title="Integrations API Documentation",
-        default_version="v4.23.0",
+        default_version="v4.23.1",
         desccription="Documentation of the Integrations APIs",
     ),
     public=True,


### PR DESCRIPTION
## Changes

- Updated tests to validate the presence of `currency_migration` in the config response, replacing the previous expectation of an empty config object.
- Introduced `CurrencyMigrationSerializer` to expose `migration_date` and `old_waba_id` from the internal `currency_migration_previous_waba_info` config field.
- Adjusted `WhatsAppConfigSerializer` to include the `currency_migration` field, defaulting to `null` when no migration data is present, ensuring backward compatibility.
- Added a new test case to verify that `currency_migration` is correctly serialized and that internal fields such as `currency_migration_previous_waba_info` and `template_id_mappings` are not exposed in the response.