### PR TITLE
fix(wpp_templates): isolate webhook change processing and improve error logging

### DIFF
--- a/marketplace/wpp_templates/tasks.py
+++ b/marketplace/wpp_templates/tasks.py
@@ -16,6 +16,42 @@ from marketplace.applications.models import App
 
 logger = logging.getLogger(__name__)
 
+ALLOWED_TEMPLATE_WEBHOOK_EVENTS = frozenset(
+    {
+        "message_template_status_update",
+        "template_correct_category_detection",
+        "template_category_update",
+    }
+)
+
+
+def _process_webhook_change(processor, waba_id, change, webhook_data) -> None:
+    """Handle one change in isolation so a malformed or failing change never
+    aborts the remaining changes in the same Meta batch."""
+    field = change.get("field")
+
+    if field not in ALLOWED_TEMPLATE_WEBHOOK_EVENTS:
+        logger.info(f"Event: {field}, not mapped to usage")
+        return
+
+    value = change.get("value")
+    if value is None:
+        logger.warning(
+            f"Webhook change for field {field} has no value, skipping. waba_id={waba_id}"
+        )
+        return
+
+    if value.get("reason") is None:
+        value["reason"] = ""
+
+    try:
+        processor.process_event(waba_id, value, field, webhook_data)
+    except Exception as e:
+        logger.error(
+            f"Failed to process webhook event field={field} waba_id={waba_id}: {e}",
+            exc_info=True,
+        )
+
 
 @shared_task(track_started=True, name="refresh_whatsapp_templates_from_facebook")
 def refresh_whatsapp_templates_from_facebook():
@@ -37,8 +73,13 @@ def refresh_whatsapp_templates_from_facebook():
             logger.error(f"Error processing app {app.uuid}: {str(e)}")
 
 
-@shared_task(track_started=True, name="update_templates_by_webhook")
-def update_templates_by_webhook(**kwargs):  # pragma: no cover
+@shared_task(
+    track_started=True,
+    name="update_templates_by_webhook",
+    acks_late=True,
+    reject_on_worker_lost=True,
+)
+def update_templates_by_webhook(**kwargs):
     """
     Celery task to handle WhatsApp webhook events related to message template status updates.
 
@@ -73,8 +114,9 @@ def update_templates_by_webhook(**kwargs):  # pragma: no cover
         }
 
     Notes:
-        - Only events with `field` equal to "message_template_status_update" are processed.
+        - Only events in ALLOWED_TEMPLATE_WEBHOOK_EVENTS are processed.
         - If the `reason` field is null, it is defaulted to an empty string.
+        - Each change is processed in isolation so one failure does not abort the batch.
         - The processor handles each app linked to the provided WABA ID.
 
     Logs:
@@ -82,31 +124,16 @@ def update_templates_by_webhook(**kwargs):  # pragma: no cover
         - Mapped and unmapped event types.
         - Processing results for each app/template.
     """
-    allowed_event_types = [
-        "message_template_status_update",
-        "template_correct_category_detection",
-        "template_category_update",
-    ]
-    webhook_data = kwargs.get("webhook_data")
+    webhook_data = kwargs.get("webhook_data") or {}
 
     logger.info(f"Update templates by webhook data received: {webhook_data}")
 
     processor = create_template_webhook_event_processor()
 
     for entry in webhook_data.get("entry", []):
-        whatsapp_business_account_id = entry.get("id")
+        waba_id = entry.get("id")
         for change in entry.get("changes", []):
-            field = change.get("field")
-            value = change.get("value")
-            if value.get("reason", None) is None:
-                value["reason"] = ""
-
-            if field in allowed_event_types:
-                processor.process_event(
-                    whatsapp_business_account_id, value, field, webhook_data
-                )
-            else:
-                logger.info(f"Event: {field}, not mapped to usage")
+            _process_webhook_change(processor, waba_id, change, webhook_data)
 
     logger.info("-" * 50)
 

--- a/marketplace/wpp_templates/tests/test_tasks.py
+++ b/marketplace/wpp_templates/tests/test_tasks.py
@@ -1,9 +1,12 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from django.test import SimpleTestCase
 
 from marketplace.applications.models import App
-from marketplace.wpp_templates.tasks import task_sync_templates_from_meta
+from marketplace.wpp_templates.tasks import (
+    task_sync_templates_from_meta,
+    update_templates_by_webhook,
+)
 
 
 class TestTaskSyncTemplatesFromMeta(SimpleTestCase):
@@ -48,3 +51,203 @@ class TestTaskSyncTemplatesFromMeta(SimpleTestCase):
         mock_logger.error.assert_called_once()
         self.assertIn("Meta rate limit", mock_logger.error.call_args.args[0])
         self.assertIn("app-uuid-123", mock_logger.error.call_args.args[0])
+
+
+def _status_change(template_name="order_confirmation", reason=""):
+    return {
+        "field": "message_template_status_update",
+        "value": {
+            "event": "APPROVED",
+            "message_template_id": 9988776655443322,
+            "message_template_name": template_name,
+            "message_template_language": "en_US",
+            "reason": reason,
+        },
+    }
+
+
+class TestUpdateTemplatesByWebhook(SimpleTestCase):
+    def test_task_options_enable_late_ack_and_reject_on_worker_lost(self):
+        self.assertTrue(update_templates_by_webhook.acks_late)
+        self.assertTrue(update_templates_by_webhook.reject_on_worker_lost)
+
+    @patch("marketplace.wpp_templates.tasks.create_template_webhook_event_processor")
+    def test_batch_with_two_entries_and_two_changes_each_reaches_processor_four_times(
+        self, mock_factory
+    ):
+        processor = MagicMock()
+        mock_factory.return_value = processor
+
+        webhook_data = {
+            "entry": [
+                {
+                    "id": "waba-1",
+                    "changes": [
+                        _status_change("tpl_a"),
+                        _status_change("tpl_b"),
+                    ],
+                },
+                {
+                    "id": "waba-2",
+                    "changes": [
+                        _status_change("tpl_c"),
+                        _status_change("tpl_d"),
+                    ],
+                },
+            ]
+        }
+
+        update_templates_by_webhook(webhook_data=webhook_data)
+
+        self.assertEqual(processor.process_event.call_count, 4)
+        processor.process_event.assert_has_calls(
+            [
+                call(
+                    "waba-1",
+                    webhook_data["entry"][0]["changes"][0]["value"],
+                    "message_template_status_update",
+                    webhook_data,
+                ),
+                call(
+                    "waba-1",
+                    webhook_data["entry"][0]["changes"][1]["value"],
+                    "message_template_status_update",
+                    webhook_data,
+                ),
+                call(
+                    "waba-2",
+                    webhook_data["entry"][1]["changes"][0]["value"],
+                    "message_template_status_update",
+                    webhook_data,
+                ),
+                call(
+                    "waba-2",
+                    webhook_data["entry"][1]["changes"][1]["value"],
+                    "message_template_status_update",
+                    webhook_data,
+                ),
+            ]
+        )
+
+    @patch("marketplace.wpp_templates.tasks.logger")
+    @patch("marketplace.wpp_templates.tasks.create_template_webhook_event_processor")
+    def test_change_with_none_value_is_skipped_and_following_changes_still_process(
+        self, mock_factory, mock_logger
+    ):
+        processor = MagicMock()
+        mock_factory.return_value = processor
+        good_change = _status_change("good")
+
+        webhook_data = {
+            "entry": [
+                {
+                    "id": "waba-1",
+                    "changes": [
+                        {
+                            "field": "message_template_status_update",
+                            "value": None,
+                        },
+                        good_change,
+                    ],
+                }
+            ]
+        }
+
+        update_templates_by_webhook(webhook_data=webhook_data)
+
+        processor.process_event.assert_called_once_with(
+            "waba-1",
+            good_change["value"],
+            "message_template_status_update",
+            webhook_data,
+        )
+        mock_logger.warning.assert_called_once()
+        self.assertIn("has no value", mock_logger.warning.call_args.args[0])
+
+    @patch("marketplace.wpp_templates.tasks.logger")
+    @patch("marketplace.wpp_templates.tasks.create_template_webhook_event_processor")
+    def test_processor_exception_on_first_change_does_not_stop_second(
+        self, mock_factory, mock_logger
+    ):
+        processor = MagicMock()
+        processor.process_event.side_effect = [Exception("boom"), None]
+        mock_factory.return_value = processor
+
+        first = _status_change("first")
+        second = _status_change("second")
+        webhook_data = {
+            "entry": [
+                {
+                    "id": "waba-1",
+                    "changes": [first, second],
+                }
+            ]
+        }
+
+        update_templates_by_webhook(webhook_data=webhook_data)
+
+        self.assertEqual(processor.process_event.call_count, 2)
+        mock_logger.error.assert_called_once()
+        self.assertTrue(mock_logger.error.call_args.kwargs.get("exc_info"))
+
+    @patch("marketplace.wpp_templates.tasks.logger")
+    @patch("marketplace.wpp_templates.tasks.create_template_webhook_event_processor")
+    def test_unmapped_field_logs_and_never_calls_processor(
+        self, mock_factory, mock_logger
+    ):
+        processor = MagicMock()
+        mock_factory.return_value = processor
+
+        update_templates_by_webhook(
+            webhook_data={
+                "entry": [
+                    {
+                        "id": "waba-1",
+                        "changes": [
+                            {
+                                "field": "phone_number_name_update",
+                                "value": {"display_phone_number": "123"},
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+        processor.process_event.assert_not_called()
+        mock_logger.info.assert_any_call(
+            "Event: phone_number_name_update, not mapped to usage"
+        )
+
+    @patch("marketplace.wpp_templates.tasks.create_template_webhook_event_processor")
+    def test_absent_webhook_data_is_noop(self, mock_factory):
+        processor = MagicMock()
+        mock_factory.return_value = processor
+
+        update_templates_by_webhook()
+
+        processor.process_event.assert_not_called()
+
+    @patch("marketplace.wpp_templates.tasks.create_template_webhook_event_processor")
+    def test_none_webhook_data_is_noop(self, mock_factory):
+        processor = MagicMock()
+        mock_factory.return_value = processor
+
+        update_templates_by_webhook(webhook_data=None)
+
+        processor.process_event.assert_not_called()
+
+    @patch("marketplace.wpp_templates.tasks.create_template_webhook_event_processor")
+    def test_reason_none_is_normalized_to_empty_string_before_dispatch(
+        self, mock_factory
+    ):
+        processor = MagicMock()
+        mock_factory.return_value = processor
+        change = _status_change(reason=None)
+
+        webhook_data = {"entry": [{"id": "waba-1", "changes": [change]}]}
+
+        update_templates_by_webhook(webhook_data=webhook_data)
+
+        dispatched_value = processor.process_event.call_args.args[1]
+        self.assertEqual(dispatched_value["reason"], "")

--- a/marketplace/wpp_templates/tests/test_utils.py
+++ b/marketplace/wpp_templates/tests/test_utils.py
@@ -60,9 +60,11 @@ class TestTemplateWebhookEventProcessor(TestCase):
 
     def test_skips_if_template_is_none(self):
         mock_app = MagicMock()
+        mock_app.uuid = "app-uuid-1"
         self.mock_app_filter.return_value.exists.return_value = True
         self.mock_app_filter.return_value.__iter__.return_value = [mock_app]
         self.mock_template_filter.return_value.first.return_value = None
+        self.processor.logger = MagicMock()
 
         self.processor.process_template_status_update(
             "123",
@@ -75,6 +77,66 @@ class TestTemplateWebhookEventProcessor(TestCase):
             {},
         )
         self.status_update_handler.handle.assert_not_called()
+        self.processor.logger.warning.assert_called_once()
+        warning_msg = self.processor.logger.warning.call_args.args[0]
+        self.assertIn("template not found", warning_msg)
+        self.assertIn("missing", warning_msg)
+        self.assertIn("APPROVED", warning_msg)
+        self.assertIn("app-uuid-1", warning_msg)
+
+    def test_skips_if_no_matching_translation(self):
+        mock_app = MagicMock()
+        mock_app.uuid = "app-uuid-1"
+        self.mock_app_filter.return_value.exists.return_value = True
+        self.mock_app_filter.return_value.__iter__.return_value = [mock_app]
+
+        mock_template = MagicMock()
+        mock_template.translations.filter.return_value = []
+        self.mock_template_filter.return_value.first.return_value = mock_template
+        self.processor.logger = MagicMock()
+
+        self.processor.process_template_status_update(
+            "123",
+            {
+                "event": "REJECTED",
+                "message_template_name": "order_confirmation",
+                "message_template_language": "pt_BR",
+                "message_template_id": "999",
+            },
+            {},
+        )
+
+        self.status_update_handler.handle.assert_not_called()
+        self.processor.logger.warning.assert_called_once()
+        warning_msg = self.processor.logger.warning.call_args.args[0]
+        self.assertIn("no matching translation", warning_msg)
+        self.assertIn("pt_BR", warning_msg)
+        self.assertIn("999", warning_msg)
+
+    def test_warns_when_message_template_id_is_missing(self):
+        mock_app = MagicMock()
+        mock_app.uuid = "app-uuid-1"
+        self.mock_app_filter.return_value.exists.return_value = True
+        self.mock_app_filter.return_value.__iter__.return_value = [mock_app]
+        self.mock_template_filter.return_value.first.return_value = None
+        self.processor.logger = MagicMock()
+
+        self.processor.process_template_status_update(
+            "123",
+            {
+                "event": "APPROVED",
+                "message_template_name": "order_confirmation",
+                "message_template_language": "en_US",
+            },
+            {},
+        )
+
+        warning_messages = [
+            call.args[0] for call in self.processor.logger.warning.call_args_list
+        ]
+        self.assertTrue(
+            any("missing message_template_id" in msg for msg in warning_messages)
+        )
 
     def test_unexpected_error_logs(self):
         mock_app = MagicMock()
@@ -95,6 +157,7 @@ class TestTemplateWebhookEventProcessor(TestCase):
             {},
         )
         self.processor.logger.error.assert_called_once()
+        self.assertTrue(self.processor.logger.error.call_args.kwargs.get("exc_info"))
 
     def test_process_event_delegates_correctly(self):
         self.processor.process_template_status_update = MagicMock()
@@ -201,9 +264,7 @@ class TestTemplateWebhookEventProcessor(TestCase):
         self.mock_template_filter.assert_not_called()
 
     @patch("marketplace.wpp_templates.utils.extract_template_data")
-    def test_process_template_category_update_updates_and_notifies(
-        self, mock_extract
-    ):
+    def test_process_template_category_update_updates_and_notifies(self, mock_extract):
         mock_extract.return_value = {"mocked": "data"}
         mock_app = MagicMock()
         mock_app.uuid = "app-uuid-1"

--- a/marketplace/wpp_templates/utils.py
+++ b/marketplace/wpp_templates/utils.py
@@ -207,18 +207,39 @@ class TemplateWebhookEventProcessor:
         template_language = value.get("message_template_language")
         message_template_id = value.get("message_template_id")
 
+        if message_template_id is None:
+            self.logger.warning(
+                f"Webhook status update missing message_template_id for "
+                f"template={template_name!r} language={template_language!r} "
+                f"status={status!r} waba_id={waba_id}"
+            )
+
         for app in apps:
             try:
                 template = TemplateMessage.objects.filter(
                     app=app, name=template_name
                 ).first()
                 if not template:
+                    self.logger.warning(
+                        f"Dropping status update: template not found. "
+                        f"app={app.uuid} waba_id={waba_id} "
+                        f"template={template_name!r} status={status!r}"
+                    )
                     continue
 
                 translations = template.translations.filter(
                     language=template_language,
                     message_template_id=message_template_id,
                 )
+                if not translations:
+                    self.logger.warning(
+                        f"Dropping status update: no matching translation. "
+                        f"app={app.uuid} waba_id={waba_id} "
+                        f"template={template_name!r} language={template_language!r} "
+                        f"message_template_id={message_template_id!r} status={status!r}"
+                    )
+                    continue
+
                 for translation in translations:
                     self.status_update_handler.handle(
                         app=app,
@@ -229,7 +250,8 @@ class TemplateWebhookEventProcessor:
                     )
             except Exception as e:
                 self.logger.error(
-                    f"Unexpected error processing template status update for App {str(app.uuid)}: {e}"
+                    f"Unexpected error processing template status update for App {str(app.uuid)}: {e}",
+                    exc_info=True,
                 )
 
     def process_template_category_change(self, waba_id: str, value: dict) -> None:


### PR DESCRIPTION
## Changes

- Introduced `_process_webhook_change` as a helper to process each webhook change in isolation, ensuring a malformed or failing change never aborts the remaining changes in the same Meta batch.
- Replaced the inline `allowed_event_types` list with a module-level `ALLOWED_TEMPLATE_WEBHOOK_EVENTS` frozenset and delegated per-change dispatch to `_process_webhook_change`, simplifying the main task loop.
- Added `acks_late=True` and `reject_on_worker_lost=True` to the `update_templates_by_webhook` task to prevent message loss if a worker dies mid-processing.
- Guarded against `None` webhook data by defaulting to an empty dict, making absent or null `webhook_data` a safe no-op.
- Added warning logs when a webhook change carries a `None` value, when a `TemplateMessage` is not found for an app, when no matching translation exists for the given language and template ID, and when `message_template_id` is absent from the payload.
- Added `exc_info=True` to error log calls in both the task and `process_template_status_update` so stack traces are captured automatically.
- Added `continue` after the missing-translation warning in `process_template_status_update` so subsequent apps in the loop are still processed.
- Added tests covering: late-ack task options, multi-entry/multi-change batches reaching the processor the correct number of times, `None` value skipping without aborting subsequent changes, processor exceptions on one change not stopping the next, unmapped fields being logged and skipped, absent or `None` webhook data being a no-op, and `reason=None` being normalized to an empty string before dispatch.