### PR TITLE
fix(whatsapp_cloud): replace internal permission with ProjectManagePermission on channels view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v4.23.2
+----------
+* fix(whatsapp_cloud): replace internal permission with ProjectManagePermission on channels view
+
 v4.23.1
 ----------
 * feat(whatsapp): expose currency_migration info in config serializer

--- a/marketplace/core/types/channels/whatsapp_cloud/tests/test_views.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/tests/test_views.py
@@ -1047,7 +1047,7 @@ class UpdateMmliteStatusTestCase(APIBaseTestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
-class ListWhatsAppCloudChannelsTestCase(PermissionTestCaseMixin, APIBaseTestCase):
+class ListWhatsAppCloudChannelsTestCase(APIBaseTestCase):
     view_class = WhatsAppCloudChannelsView
 
     def setUp(self):
@@ -1057,7 +1057,6 @@ class ListWhatsAppCloudChannelsTestCase(PermissionTestCaseMixin, APIBaseTestCase
         self.other_project_uuid = str(uuid.uuid4())
         self.url = reverse("wpp-cloud-channels")
 
-        self.grant_permission(self.user, "can_communicate_internally")
         self.request.set_auth(WeniAuthContext(project_uuid=self.project_uuid))
 
     @property
@@ -1113,14 +1112,11 @@ class ListWhatsAppCloudChannelsTestCase(PermissionTestCaseMixin, APIBaseTestCase
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_list_denies_non_internal_user(self):
-        self.revoke_permission(self.user, "can_communicate_internally")
+    def test_list_allows_authenticated_jwt_user_without_internal_permission(self):
+        response = self.request.get(self.url)
 
-        response = self.request.get(
-            self.url, params={"project_uuid": self.project_uuid}
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json, [])
 
     def test_list_exposes_channel_identifiers_from_nested_config(self):
         flow_object_uuid = str(uuid.uuid4())

--- a/marketplace/core/types/channels/whatsapp_cloud/views.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/views.py
@@ -12,10 +12,7 @@ from rest_framework.exceptions import APIException
 from django.conf import settings
 from django.utils.crypto import get_random_string
 
-from weni_commons.auth import (
-    CanCommunicateInternally as WeniCanCommunicateInternally,
-    WeniAuthViewMixin,
-)
+from weni_commons.auth import WeniAuthViewMixin
 
 from marketplace.accounts.authentication import WeniModuleAuthentication
 from marketplace.core.types import views
@@ -313,14 +310,14 @@ class WhatsAppCloudViewSet(
 
 class WhatsAppCloudChannelsView(WeniAuthViewMixin, APIView):
     """List every WhatsApp Cloud channel of a project for the channel-selection
-    screen consumed by internal services (e.g. retail).
+    screen consumed by authenticated callers (e.g. agentic-cx).
 
-    Always scoped to the required `project_uuid`, so other projects' channels
+    Always scoped to ``self.auth.project_uuid``, so other projects' channels
     are never leaked.
     """
 
     authentication_classes = [WeniModuleAuthentication]
-    permission_classes = [WeniCanCommunicateInternally]
+    permission_classes = [ProjectManagePermission]
 
     def get(self, request, *args, **kwargs):
         apps = ListWhatsAppCloudChannelsUseCase().execute(

--- a/marketplace/swagger.py
+++ b/marketplace/swagger.py
@@ -6,7 +6,7 @@ from rest_framework import permissions
 view = get_schema_view(
     openapi.Info(
         title="Integrations API Documentation",
-        default_version="v4.23.1",
+        default_version="v4.23.2",
         desccription="Documentation of the Integrations APIs",
     ),
     public=True,


### PR DESCRIPTION
- Replaced `WeniCanCommunicateInternally` with `ProjectManagePermission` in `WhatsAppCloudChannelsView`, broadening access to authenticated callers (e.g. agentic-cx) rather than restricting it to internal services.
- Removed the `can_communicate_internally` permission requirement from `ListWhatsAppCloudChannelsTestCase`, aligning tests with the updated access control logic.
- Renamed `test_list_denies_non_internal_user` to `test_list_allows_authenticated_jwt_user_without_internal_permission` and updated its assertions to expect a `200 OK` response with an empty list instead of a `403 Forbidden`.